### PR TITLE
Setup versioning for releases

### DIFF
--- a/src/iOS/Go Map!!-Info.plist
+++ b/src/iOS/Go Map!!-Info.plist
@@ -61,7 +61,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.6.2</string>
+	<string>1</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -2928,7 +2928,7 @@
 				DISPLAY_NAME = "OSM Completionist Debug";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Go Map!!-Prefix.pch";
-				INFOPLIST_FILE = "$(SRCROOT)/Go Map!!-Info.plist";
+				INFOPLIST_FILE = "Go Map!!-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "de.wtimme.osm-completionist";
@@ -2956,7 +2956,7 @@
 				DISPLAY_NAME = "OSM Completionist";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Go Map!!-Prefix.pch";
-				INFOPLIST_FILE = "$(SRCROOT)/Go Map!!-Info.plist";
+				INFOPLIST_FILE = "Go Map!!-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "de.wtimme.osm-completionist";

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -2923,6 +2923,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = CH829V2QQB;
 				DISPLAY_NAME = "OSM Completionist Debug";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -2950,6 +2951,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = CH829V2QQB;
 				DISPLAY_NAME = "OSM Completionist";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -2936,6 +2936,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/Go Map!!-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -2961,6 +2962,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/Go Map!!-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/src/iOS/GoMapTests/Info.plist
+++ b/src/iOS/GoMapTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/src/iOS/GoMapUITests/Info.plist
+++ b/src/iOS/GoMapUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
This branch sets up the project to use the "Apple Generic" versioning system. It further sets the build number to `1` (a valid integer, as per the documentation) so that the build number can be incremented automatically later on.