### PR TITLE
Setup fastlane match

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ for iPhone/iPad.
 If you're looking for **a full OpenStreetMap editor**,
 [download GoMap on the App Store][3].
 
+## Signing
+
+To automate the signing, this project uses [fastlane match][5].
+Fetch the certificates for development with
+
+    % bundle exec fastlane match development
+
 ## Source code structure
 
 * iOS - Code specific to the iOS app
@@ -28,3 +35,4 @@ If you're looking for **a full OpenStreetMap editor**,
 [2]: https://github.com/bryceco/GoMap
 [3]: https://itunes.apple.com/app/id592990211
 [4]: https://wiki.openstreetmap.org/wiki/StreetComplete/Quests
+[5]: https://docs.fastlane.tools/actions/match/

--- a/src/iOS/fastlane/Appfile
+++ b/src/iOS/fastlane/Appfile
@@ -1,6 +1,0 @@
-# app_identifier("[[APP_IDENTIFIER]]") # The bundle identifier of your app
-# apple_id("[[APPLE_ID]]") # Your Apple email address
-
-
-# For more information about the Appfile, see:
-#     https://docs.fastlane.tools/advanced/#appfile

--- a/src/iOS/fastlane/Appfile
+++ b/src/iOS/fastlane/Appfile
@@ -1,0 +1,2 @@
+app_identifier "de.wtimme.osm-completionist"
+team_id "CH829V2QQB"

--- a/src/iOS/fastlane/Matchfile
+++ b/src/iOS/fastlane/Matchfile
@@ -1,0 +1,13 @@
+git_url("git@github.com:wtimme/OSM-Completionist-certificates.git")
+
+storage_mode("git")
+
+type("development") # The default type, can be: appstore, adhoc, enterprise or development
+
+# app_identifier(["tools.fastlane.app", "tools.fastlane.app2"])
+# username("user@fastlane.tools") # Your Apple Developer Portal username
+
+# For all available options run `fastlane match --help`
+# Remove the # in the beginning of the line to enable the other options
+
+# The docs are available on https://docs.fastlane.tools/actions/match

--- a/src/iOS/fastlane/Matchfile
+++ b/src/iOS/fastlane/Matchfile
@@ -3,11 +3,3 @@ git_url("git@github.com:wtimme/OSM-Completionist-certificates.git")
 storage_mode("git")
 
 type("development") # The default type, can be: appstore, adhoc, enterprise or development
-
-# app_identifier(["tools.fastlane.app", "tools.fastlane.app2"])
-# username("user@fastlane.tools") # Your Apple Developer Portal username
-
-# For all available options run `fastlane match --help`
-# Remove the # in the beginning of the line to enable the other options
-
-# The docs are available on https://docs.fastlane.tools/actions/match


### PR DESCRIPTION
This branch sets up [fastlane match][1], making it easier to manage the provisioning profiles and certificates.

[1]: https://docs.fastlane.tools/actions/match/