### PR TITLE
Fix caching of Bundler Gems when using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 before_install:
   - cd src/iOS
 install:
-  - "bundle install"
+  - "bundle install --deployment"
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: objective-c
 osx_image: xcode11.2
 cache:
-  - bundler
+  directories:
+    - src/iOS/vendor/bundle
 before_install:
   - cd src/iOS
 install:


### PR DESCRIPTION
This branch makes sure that the Gems that are installed with Bundler will be cached for Travis, in an effort to reduce build time.