### PR TITLE
Enable UI tests for pull requests

### DIFF
--- a/src/iOS/GoMapUITests/Helper/XCUIElement+TestHelper.swift
+++ b/src/iOS/GoMapUITests/Helper/XCUIElement+TestHelper.swift
@@ -24,7 +24,7 @@ extension XCUIElement {
         XCUIApplication().menuItems["Select All"].tap()
         
         // Reset it to an empty string.
-        XCUIApplication().keys["delete"].tap()
+        typeText(XCUIKeyboardKey.delete.rawValue)
     }
     
 }

--- a/src/iOS/fastlane/Fastfile
+++ b/src/iOS/fastlane/Fastfile
@@ -8,6 +8,7 @@ platform :ios do
   desc "Performs basic integration checks to be run before merging"
   lane :pull_request_checks do
     run_tests(scheme: "GoMapTests")
+    run_tests(scheme: "GoMapUITests")
   end
 
   desc "Uploads a new Beta version to TestFlight"


### PR DESCRIPTION
This branch configures fastlane so that the UI test scheme is run during the `pull_request_checks` lane. In addition, it fixes the helper method that clears the text field (which had caused the UI tests to fail).