### PR TITLE
Remove `UISearchDisplayController` from storyboard

### DIFF
--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -3704,18 +3704,9 @@ This Privacy Policy may be updated from time to time for any reason. We will not
                         <outlet property="_activityIndicator" destination="BJx-hX-58b" id="Qaa-v5-g28"/>
                         <outlet property="_searchBar" destination="xw9-Ro-Fai" id="uxK-r6-i4V"/>
                         <outlet property="_tableView" destination="abd-jd-9tI" id="JEm-Wo-mtE"/>
-                        <outlet property="searchDisplayController" destination="yyz-Me-8kv" id="3kV-uC-rTf"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xdo-ip-Va2" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <searchDisplayController id="yyz-Me-8kv">
-                    <connections>
-                        <outlet property="delegate" destination="siu-I6-IEp" id="amY-4c-akr"/>
-                        <outlet property="searchContentsController" destination="siu-I6-IEp" id="3AQ-Pi-vqH"/>
-                        <outlet property="searchResultsDataSource" destination="siu-I6-IEp" id="LcQ-9A-mJN"/>
-                        <outlet property="searchResultsDelegate" destination="siu-I6-IEp" id="qKF-z8-srs"/>
-                    </connections>
-                </searchDisplayController>
             </objects>
             <point key="canvasLocation" x="139" y="-1104"/>
         </scene>

--- a/src/iOS/Go Map!!-Info.plist
+++ b/src/iOS/Go Map!!-Info.plist
@@ -61,7 +61,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -2928,7 +2928,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = CH829V2QQB;
 				DISPLAY_NAME = "Completionist Debug";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -2957,7 +2957,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = CH829V2QQB;
 				DISPLAY_NAME = Completionist;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/src/iOS/GoMapTests/Info.plist
+++ b/src/iOS/GoMapTests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 </dict>
 </plist>

--- a/src/iOS/GoMapUITests/Info.plist
+++ b/src/iOS/GoMapUITests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 </dict>
 </plist>


### PR DESCRIPTION
While testing the app with TestFlight, I was experiencing
the same crash as described in this [Stack Overflow post][1],
so I removed the item from the storyboard.

I ran the app in DEBUG on my device, and the search still
opens fine when long-pressing the location arrow.

[1]: https://stackoverflow.com/q/57819165