### PR TITLE
Feature: Center Overpass Turbo preview page on current location

### DIFF
--- a/src/iOS/Go Map!!-Bridging-Header.h
+++ b/src/iOS/Go Map!!-Bridging-Header.h
@@ -11,3 +11,4 @@
 #import "SettingsViewController.h"
 #import "DisplayViewController.h"
 #import "EditorMapLayer.h"
+#import "MapView.h"

--- a/src/iOS/GoMapTests/Mocks/QueryFormViewModelDelegateMock.swift
+++ b/src/iOS/GoMapTests/Mocks/QueryFormViewModelDelegateMock.swift
@@ -10,6 +10,8 @@ import Foundation
 @testable import Go_Map__
 
 class QueryFormViewModelDelegateMock: NSObject {
+    var previewCenterCoordinate: CLLocationCoordinate2D?
+    
     var didCallPresentPreview = false
     var previewURL: String?
 }

--- a/src/iOS/GoMapTests/Overpass/QueryFormViewModelTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/QueryFormViewModelTestCase.swift
@@ -159,6 +159,42 @@ class QueryFormViewModelTestCase: XCTestCase {
         XCTAssertEqual(delegateMock.previewURL, expectedURL)
     }
     
+    // MARK: presentPreview and center on coordinate
+    
+    func testPresentPreview_withValidQueryAndWithoutPreviewCenterCoordinate_shouldNotAddLatLonToURL() {
+        /// Given
+        delegateMock.previewCenterCoordinate = nil
+        
+        /// When
+        let query = "type:node and man_made=surveillance and camera:mount=pole"
+        viewModel.evaluateQuery(query)
+        
+        viewModel.presentPreview()
+        
+        /// Then
+        let encodedQuery = "type%3Anode%20and%20man_made%3Dsurveillance%20and%20camera%3Amount%3Dpole"
+        let expectedURL = "https://overpass-turbo.eu?w=\(encodedQuery)&R"
+        XCTAssertEqual(delegateMock.previewURL, expectedURL)
+    }
+    
+    func testPresentPreview_withValidQueryAndPreviewCenterCoordinate_shouldAddLatLonToURL() {
+        /// Given
+        let latitude = 1.234
+        let longitude = 5.678
+        delegateMock.previewCenterCoordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        
+        /// When
+        let query = "type:node and man_made=surveillance and camera:mount=pole"
+        viewModel.evaluateQuery(query)
+        
+        viewModel.presentPreview()
+        
+        /// Then
+        let encodedQuery = "type%3Anode%20and%20man_made%3Dsurveillance%20and%20camera%3Amount%3Dpole"
+        let expectedURL = "https://overpass-turbo.eu?w=\(encodedQuery)&R&lat=\(latitude)&lon=\(longitude)"
+        XCTAssertEqual(delegateMock.previewURL, expectedURL)
+    }
+    
     // MARK: viewWillDisappear
     
     func testViewWillDisappearShouldSetTheActiveQuestToNilWhenTheQueryIsNotValid() {

--- a/src/iOS/Overpass/QueryForm/QueryFormViewController.swift
+++ b/src/iOS/Overpass/QueryForm/QueryFormViewController.swift
@@ -166,6 +166,11 @@ extension QueryFormViewController: UIGestureRecognizerDelegate {
 }
 
 extension QueryFormViewController: QueryFormViewModelDelegate {
+    var previewCenterCoordinate: CLLocationCoordinate2D? {
+        /// TODO: Implement me
+        return nil
+    }
+    
     func presentPreviewWithOverpassTurbo(url: String) {
         guard let url = URL(string: url) else { return }
         

--- a/src/iOS/Overpass/QueryForm/QueryFormViewController.swift
+++ b/src/iOS/Overpass/QueryForm/QueryFormViewController.swift
@@ -167,8 +167,15 @@ extension QueryFormViewController: UIGestureRecognizerDelegate {
 
 extension QueryFormViewController: QueryFormViewModelDelegate {
     var previewCenterCoordinate: CLLocationCoordinate2D? {
-        /// TODO: Implement me
-        return nil
+        guard
+            let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+            let mapView = appDelegate.mapView
+        else {
+            /// Without the map view, we cannot get the center coordinate.
+            return nil
+        }
+        
+        return mapView.longitudeLatitude(forScreenPoint: mapView.center, birdsEye: true)
     }
     
     func presentPreviewWithOverpassTurbo(url: String) {

--- a/src/iOS/Overpass/QueryForm/QueryFormViewModel.swift
+++ b/src/iOS/Overpass/QueryForm/QueryFormViewModel.swift
@@ -9,6 +9,9 @@
 import Foundation
 
 protocol QueryFormViewModelDelegate: class {
+    /// The coordinate that the Overpass Turbo preview should centered on
+    var previewCenterCoordinate: CLLocationCoordinate2D? { get }
+    
     /// Asks the delegate to present the preview with the given URL string.
     ///
     /// - Parameter url: The URL of the preview address as a string.
@@ -91,7 +94,15 @@ class QueryFormViewModel: NSObject {
             return
         }
         
-        let previewURL = "https://overpass-turbo.eu?w=\(escapedQuery)&R"
+        /// Attempt to center the preview's map on a specific coordinate.
+        let centerCoordinateURLPart: String
+        if let coordinate = delegate?.previewCenterCoordinate {
+            centerCoordinateURLPart = "&lat=\(coordinate.latitude)&lon=\(coordinate.longitude)"
+        } else {
+            centerCoordinateURLPart = ""
+        }
+        
+        let previewURL = "https://overpass-turbo.eu?w=\(escapedQuery)&R\(centerCoordinateURLPart)"
         delegate?.presentPreviewWithOverpassTurbo(url: previewURL)
     }
     


### PR DESCRIPTION
This branch implements #24 and centers the Overpass Turbo preview page on the map's current location.