### PR TITLE
Feature: Indicate purpose of Overpass Query Wizard better

### DIFF
--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -4515,7 +4515,7 @@ This Privacy Policy may be updated from time to time for any reason. We will not
                                             <rect key="frame" x="0.0" y="0.0" width="301" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Overpass Query" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ULV-fp-ygV">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Overpass Query Wizard" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ULV-fp-ygV">
                                                     <rect key="frame" x="15" y="0.0" width="278" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>

--- a/src/iOS/GoMapUITests/OverpassQueryFormUITestCase.swift
+++ b/src/iOS/GoMapUITests/OverpassQueryFormUITestCase.swift
@@ -189,14 +189,14 @@ class OverpassQueryFormUITestCase: XCTestCase {
         
         // Go back to the query form.
         app.cells["overpass_query"].tap()
-        waitForViewController("Overpass Query")
+        waitForViewController("Overpass Query Wizard")
         
         // Tap the back button.
         app.tapBackButton()
         
         // Go back to the query form.
         app.cells["overpass_query"].tap()
-        waitForViewController("Overpass Query")
+        waitForViewController("Overpass Query Wizard")
         
         XCTAssertEqual(app.textViews["query_text_view"].value as? String, query)
     }
@@ -217,7 +217,7 @@ class OverpassQueryFormUITestCase: XCTestCase {
         
         // Go back to the query form.
         app.cells["overpass_query"].tap()
-        waitForViewController("Overpass Query")
+        waitForViewController("Overpass Query Wizard")
         
         XCTAssertTrue((app.textViews["query_text_view"].value as? String)?.isEmpty ?? false)
     }
@@ -238,7 +238,7 @@ class OverpassQueryFormUITestCase: XCTestCase {
         
         // Go back to the query form.
         app.cells["overpass_query"].tap()
-        waitForViewController("Overpass Query")
+        waitForViewController("Overpass Query Wizard")
         
         XCTAssertTrue(app.buttons["preview_button"].isEnabled)
     }
@@ -253,7 +253,7 @@ class OverpassQueryFormUITestCase: XCTestCase {
         
         app.cells["overpass_query"].tap()
         
-        waitForViewController("Overpass Query")
+        waitForViewController("Overpass Query Wizard")
     }
 
 }

--- a/src/iOS/GoMapUITests/OverpassQueryFormUITestCase.swift
+++ b/src/iOS/GoMapUITests/OverpassQueryFormUITestCase.swift
@@ -171,6 +171,16 @@ class OverpassQueryFormUITestCase: XCTestCase {
         wait(for: [elementExistsExpectation], timeout: 3)
     }
     
+    func testTappingOnHelpButton_shouldPresentTheOpenStreetMapWiki() {
+        goToOverpassQueryViewController()
+        
+        app.buttons["help"].tap()
+        
+        let elementExistsExpectation = expectation(for: NSPredicate(format: "exists == 1"),
+                                                   evaluatedWith: app.webViews.firstMatch)
+        wait(for: [elementExistsExpectation], timeout: 3)
+    }
+    
     // MARK: Persistence
     
     func testTappingBackWhenAValidQueryIsEnteredShouldSaveTheQuery() {

--- a/src/iOS/Overpass/QueryForm/QueryFormViewController.swift
+++ b/src/iOS/Overpass/QueryForm/QueryFormViewController.swift
@@ -30,6 +30,7 @@ class QueryFormViewController: UIViewController {
         
         bindToViewModel()
         
+        setupHelpButton()
         startListeningForKeyboardNotifications()
         setupKeyboardDismissOnTapGestureRecognizer()
     }
@@ -138,6 +139,26 @@ class QueryFormViewController: UIViewController {
     
     @objc private func dismissKeyboard() {
         view.endEditing(true)
+    }
+    
+    // MARK: Help Button
+    
+    private func setupHelpButton() {
+        let infoButton = UIButton(type: .infoLight)
+        infoButton.accessibilityIdentifier = "help"
+        infoButton.addTarget(self,
+                             action: #selector(openOverpassTurboWizardHelpPage),
+                             for: .touchUpInside)
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: infoButton)
+    }
+    
+    @IBAction private func openOverpassTurboWizardHelpPage() {
+        guard let url = URL(string: "https://wiki.openstreetmap.org/wiki/Overpass_turbo/Wizard#Purpose") else { return }
+        
+        let viewController = SFSafariViewController(url: url,
+                                                    entersReaderIfAvailable: true)
+        present(viewController, animated: true)
     }
     
     // MARK: Preview Button

--- a/src/iOS/Overpass/QueryForm/QueryFormViewController.swift
+++ b/src/iOS/Overpass/QueryForm/QueryFormViewController.swift
@@ -24,7 +24,7 @@ class QueryFormViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        title = "Overpass Query"
+        title = "Overpass Query Wizard"
         
         textView.delegate = self
         


### PR DESCRIPTION
This branch updates the title of the Wizard view to better communicate what the user is supposed to enter.

Furthermore, it adds a "Help" button that, when tapped, opens the [OpenStreetMap wiki][1].

---

_This is the same as #26, but with the correct issue ID (#13)._

[1]: https://wiki.openstreetmap.org/wiki/Overpass_turbo/Wizard#Purpose