### PR TITLE
Feature: List of quests

### DIFF
--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -4526,6 +4526,24 @@ This Privacy Policy may be updated from time to time for any reason. We will not
                                         </tableViewCellContentView>
                                         <accessibility key="accessibilityConfiguration" identifier="overpass_query"/>
                                     </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="RH6-ev-L6M" style="IBUITableViewCellStyleDefault" id="MhJ-kQ-Ich">
+                                        <rect key="frame" x="0.0" y="727.5" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="MhJ-kQ-Ich" id="3Ou-Ni-25E">
+                                            <rect key="frame" x="0.0" y="0.0" width="293" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Quests" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="RH6-ev-L6M">
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <accessibility key="accessibilityConfiguration" identifier="quests"/>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Interactions" id="RJU-Z2-QFh">

--- a/src/iOS/DisplayViewController.m
+++ b/src/iOS/DisplayViewController.m
@@ -143,6 +143,8 @@ static const NSInteger FILTER_SECTION = 3;
 
     } else if (indexPath.section == FILTER_SECTION && indexPath.row == 1) {
         [self presentOverpassQueryViewController];
+    } else if (indexPath.section == FILTER_SECTION && indexPath.row == 2) {
+        [self presentQuestListViewController];
     }
 	[self.tableView deselectRowAtIndexPath:indexPath animated:YES];
 

--- a/src/iOS/Extensions/DisplayViewController.swift
+++ b/src/iOS/Extensions/DisplayViewController.swift
@@ -7,6 +7,12 @@
 //
 
 extension DisplayViewController {
+    @objc func presentQuestListViewController() {
+        let viewController = QuestListTableViewController()
+        
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+    
     @objc func presentOverpassQueryViewController() {
         let viewController = QueryFormViewController()
         

--- a/src/iOS/Extensions/EditorMapLayer.swift
+++ b/src/iOS/Extensions/EditorMapLayer.swift
@@ -10,12 +10,12 @@
     
     func observeQuestChanges() {
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(didReceiveActiveQuestChangedNotification(_:)),
-                                               name: .QuestManagerDidUpdateActiveQuest,
+                                               selector: #selector(didReceiveActiveQuestsChangedNotification(_:)),
+                                               name: .QuestManagerDidUpdateActiveQuests,
                                                object: nil)
     }
     
-    func didReceiveActiveQuestChangedNotification(_ note: Notification) {
+    func didReceiveActiveQuestsChangedNotification(_ note: Notification) {
         resetDisplayLayers()
     }
     

--- a/src/iOS/Go Map!!-Info.plist
+++ b/src/iOS/Go Map!!-Info.plist
@@ -61,7 +61,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -526,6 +526,7 @@
 		64CCF4D923C0B708006164D3 /* QuestListViewModelTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4D823C0B708006164D3 /* QuestListViewModelTestCase.swift */; };
 		64CCF4DB23C0B8D0006164D3 /* Quest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4DA23C0B8D0006164D3 /* Quest.swift */; };
 		64CCF4DD23C0BDDF006164D3 /* QuestProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4DC23C0BDDF006164D3 /* QuestProviding.swift */; };
+		64CCF4DF23C0BEC0006164D3 /* StaticQuestProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4DE23C0BEC0006164D3 /* StaticQuestProvider.swift */; };
 		64D64CE2227ECEA20040C67A /* OsmBaseObject+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */; };
 		64D64CE9227ECF450040C67A /* BaseObjectMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */; };
 		64D64CEC227ED0790040C67A /* KeyExistsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */; };
@@ -1182,6 +1183,7 @@
 		64CCF4D823C0B708006164D3 /* QuestListViewModelTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListViewModelTestCase.swift; sourceTree = "<group>"; };
 		64CCF4DA23C0B8D0006164D3 /* Quest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quest.swift; sourceTree = "<group>"; };
 		64CCF4DC23C0BDDF006164D3 /* QuestProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestProviding.swift; sourceTree = "<group>"; };
+		64CCF4DE23C0BEC0006164D3 /* StaticQuestProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticQuestProvider.swift; sourceTree = "<group>"; };
 		64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OsmBaseObject+Make.swift"; sourceTree = "<group>"; };
 		64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObjectMatching.swift; sourceTree = "<group>"; };
 		64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyExistsQuery.swift; sourceTree = "<group>"; };
@@ -2021,6 +2023,7 @@
 				64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */,
 				64CCF4D523C0B6B8006164D3 /* QuestListViewModel.swift */,
 				64CCF4DC23C0BDDF006164D3 /* QuestProviding.swift */,
+				64CCF4DE23C0BEC0006164D3 /* StaticQuestProvider.swift */,
 			);
 			path = QuestList;
 			sourceTree = "<group>";
@@ -2743,6 +2746,7 @@
 				02FFCE0B16A7360B001A5B8A /* NSMutableArray+PartialSort.mm in Sources */,
 				027EDC73206F3EED00D349D6 /* DDXMLDocument.m in Sources */,
 				028F504519B949780093C423 /* CommonTagList.m in Sources */,
+				64CCF4DF23C0BEC0006164D3 /* StaticQuestProvider.swift in Sources */,
 				024ADF3C16B1B38B00875658 /* PathUtil.m in Sources */,
 				02CB5B6516BF1F9C00432914 /* AutocompleteTextField.m in Sources */,
 				02F04AD21BC4D3B50044FD95 /* GpxConfigureViewController.m in Sources */,

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -523,6 +523,7 @@
 		64CCF4D323C0B182006164D3 /* QuestListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4D123C0B182006164D3 /* QuestListTableViewController.swift */; };
 		64CCF4D423C0B182006164D3 /* QuestListTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */; };
 		64CCF4D623C0B6B8006164D3 /* QuestListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4D523C0B6B8006164D3 /* QuestListViewModel.swift */; };
+		64CCF4D923C0B708006164D3 /* QuestListViewModelTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4D823C0B708006164D3 /* QuestListViewModelTestCase.swift */; };
 		64D64CE2227ECEA20040C67A /* OsmBaseObject+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */; };
 		64D64CE9227ECF450040C67A /* BaseObjectMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */; };
 		64D64CEC227ED0790040C67A /* KeyExistsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */; };
@@ -1176,6 +1177,7 @@
 		64CCF4D123C0B182006164D3 /* QuestListTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListTableViewController.swift; sourceTree = "<group>"; };
 		64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuestListTableViewController.xib; sourceTree = "<group>"; };
 		64CCF4D523C0B6B8006164D3 /* QuestListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListViewModel.swift; sourceTree = "<group>"; };
+		64CCF4D823C0B708006164D3 /* QuestListViewModelTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListViewModelTestCase.swift; sourceTree = "<group>"; };
 		64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OsmBaseObject+Make.swift"; sourceTree = "<group>"; };
 		64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObjectMatching.swift; sourceTree = "<group>"; };
 		64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyExistsQuery.swift; sourceTree = "<group>"; };
@@ -2053,6 +2055,7 @@
 				64B2AD182280E5E500204F8B /* QueryFormViewModelTestCase.swift */,
 				64972EA122822BDB00286157 /* QuestManagerTestCase.swift */,
 				64972EAA22858FDF00286157 /* MapViewQuestAnnotationManagerTestCase.swift */,
+				64CCF4D823C0B708006164D3 /* QuestListViewModelTestCase.swift */,
 			);
 			path = Overpass;
 			sourceTree = "<group>";
@@ -2771,6 +2774,7 @@
 				64972E9922820ACD00286157 /* QueryFormViewModelDelegateMock.swift in Sources */,
 				64B2AD1B2280EAAB00204F8B /* OverpassQueryParserMock.swift in Sources */,
 				64C072FE22622B9C00598078 /* Require.swift in Sources */,
+				64CCF4D923C0B708006164D3 /* QuestListViewModelTestCase.swift in Sources */,
 				64348CFD225E867800ADE7FB /* CLHeadingMock.swift in Sources */,
 				64348D03225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift in Sources */,
 				64E21EB522651C06004605D7 /* OSMMapDataTestCase.swift in Sources */,

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -530,6 +530,7 @@
 		64CCF4E123C0C04C006164D3 /* QuestProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4E023C0C04C006164D3 /* QuestProviderMock.swift */; };
 		64CCF4E323C0C1BF006164D3 /* Quest+MakeQuest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4E223C0C1BF006164D3 /* Quest+MakeQuest.swift */; };
 		64CCF4E523C0DC2E006164D3 /* StaticQuestProviderTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4E423C0DC2E006164D3 /* StaticQuestProviderTestCase.swift */; };
+		64CCF4E723C13F67006164D3 /* QuestListViewModelDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4E623C13F67006164D3 /* QuestListViewModelDelegateMock.swift */; };
 		64D64CE2227ECEA20040C67A /* OsmBaseObject+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */; };
 		64D64CE9227ECF450040C67A /* BaseObjectMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */; };
 		64D64CEC227ED0790040C67A /* KeyExistsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */; };
@@ -1190,6 +1191,7 @@
 		64CCF4E023C0C04C006164D3 /* QuestProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestProviderMock.swift; sourceTree = "<group>"; };
 		64CCF4E223C0C1BF006164D3 /* Quest+MakeQuest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Quest+MakeQuest.swift"; sourceTree = "<group>"; };
 		64CCF4E423C0DC2E006164D3 /* StaticQuestProviderTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticQuestProviderTestCase.swift; sourceTree = "<group>"; };
+		64CCF4E623C13F67006164D3 /* QuestListViewModelDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListViewModelDelegateMock.swift; sourceTree = "<group>"; };
 		64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OsmBaseObject+Make.swift"; sourceTree = "<group>"; };
 		64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObjectMatching.swift; sourceTree = "<group>"; };
 		64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyExistsQuery.swift; sourceTree = "<group>"; };
@@ -1976,6 +1978,7 @@
 				64972EA3228230F000286157 /* QuestManagerMock.swift */,
 				64D64CED227ED11F0040C67A /* BaseObjectMatcherMock.swift */,
 				64CCF4E023C0C04C006164D3 /* QuestProviderMock.swift */,
+				64CCF4E623C13F67006164D3 /* QuestListViewModelDelegateMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2779,6 +2782,7 @@
 				64C072FA226227D500598078 /* CommonTagKeyTestCase.swift in Sources */,
 				64D64CF8227ED2480040C67A /* KeyExistsQueryTestCase.swift in Sources */,
 				64D64CEE227ED11F0040C67A /* BaseObjectMatcherMock.swift in Sources */,
+				64CCF4E723C13F67006164D3 /* QuestListViewModelDelegateMock.swift in Sources */,
 				64972EA222822BDB00286157 /* QuestManagerTestCase.swift in Sources */,
 				64CCF4E123C0C04C006164D3 /* QuestProviderMock.swift in Sources */,
 				64972EA4228230F000286157 /* QuestManagerMock.swift in Sources */,

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -528,6 +528,7 @@
 		64CCF4DD23C0BDDF006164D3 /* QuestProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4DC23C0BDDF006164D3 /* QuestProviding.swift */; };
 		64CCF4DF23C0BEC0006164D3 /* StaticQuestProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4DE23C0BEC0006164D3 /* StaticQuestProvider.swift */; };
 		64CCF4E123C0C04C006164D3 /* QuestProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4E023C0C04C006164D3 /* QuestProviderMock.swift */; };
+		64CCF4E323C0C1BF006164D3 /* Quest+MakeQuest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4E223C0C1BF006164D3 /* Quest+MakeQuest.swift */; };
 		64D64CE2227ECEA20040C67A /* OsmBaseObject+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */; };
 		64D64CE9227ECF450040C67A /* BaseObjectMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */; };
 		64D64CEC227ED0790040C67A /* KeyExistsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */; };
@@ -1186,6 +1187,7 @@
 		64CCF4DC23C0BDDF006164D3 /* QuestProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestProviding.swift; sourceTree = "<group>"; };
 		64CCF4DE23C0BEC0006164D3 /* StaticQuestProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticQuestProvider.swift; sourceTree = "<group>"; };
 		64CCF4E023C0C04C006164D3 /* QuestProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestProviderMock.swift; sourceTree = "<group>"; };
+		64CCF4E223C0C1BF006164D3 /* Quest+MakeQuest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Quest+MakeQuest.swift"; sourceTree = "<group>"; };
 		64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OsmBaseObject+Make.swift"; sourceTree = "<group>"; };
 		64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObjectMatching.swift; sourceTree = "<group>"; };
 		64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyExistsQuery.swift; sourceTree = "<group>"; };
@@ -2121,6 +2123,7 @@
 			isa = PBXGroup;
 			children = (
 				64E21EB722651F2D004605D7 /* XCTestCase+UserDefaults.swift */,
+				64CCF4E223C0C1BF006164D3 /* Quest+MakeQuest.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -2783,6 +2786,7 @@
 				64D64D0A227EF3790040C67A /* TypeQueryTestCase.swift in Sources */,
 				64972EAB22858FDF00286157 /* MapViewQuestAnnotationManagerTestCase.swift in Sources */,
 				64D64D05227ED75A0040C67A /* OverpassQueryParserTestCase.swift in Sources */,
+				64CCF4E323C0C1BF006164D3 /* Quest+MakeQuest.swift in Sources */,
 				64348CFB225E867800ADE7FB /* HeadingProviderMock.swift in Sources */,
 				64E21EB822651F2D004605D7 /* XCTestCase+UserDefaults.swift in Sources */,
 				64D64CE2227ECEA20040C67A /* OsmBaseObject+Make.swift in Sources */,

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -522,6 +522,7 @@
 		64CCF4CF23C0B052006164D3 /* QuestListUITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4CE23C0B052006164D3 /* QuestListUITestCase.swift */; };
 		64CCF4D323C0B182006164D3 /* QuestListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4D123C0B182006164D3 /* QuestListTableViewController.swift */; };
 		64CCF4D423C0B182006164D3 /* QuestListTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */; };
+		64CCF4D623C0B6B8006164D3 /* QuestListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4D523C0B6B8006164D3 /* QuestListViewModel.swift */; };
 		64D64CE2227ECEA20040C67A /* OsmBaseObject+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */; };
 		64D64CE9227ECF450040C67A /* BaseObjectMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */; };
 		64D64CEC227ED0790040C67A /* KeyExistsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */; };
@@ -1174,6 +1175,7 @@
 		64CCF4CE23C0B052006164D3 /* QuestListUITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListUITestCase.swift; sourceTree = "<group>"; };
 		64CCF4D123C0B182006164D3 /* QuestListTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListTableViewController.swift; sourceTree = "<group>"; };
 		64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuestListTableViewController.xib; sourceTree = "<group>"; };
+		64CCF4D523C0B6B8006164D3 /* QuestListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListViewModel.swift; sourceTree = "<group>"; };
 		64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OsmBaseObject+Make.swift"; sourceTree = "<group>"; };
 		64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObjectMatching.swift; sourceTree = "<group>"; };
 		64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyExistsQuery.swift; sourceTree = "<group>"; };
@@ -2011,6 +2013,7 @@
 			children = (
 				64CCF4D123C0B182006164D3 /* QuestListTableViewController.swift */,
 				64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */,
+				64CCF4D523C0B6B8006164D3 /* QuestListViewModel.swift */,
 			);
 			path = QuestList;
 			sourceTree = "<group>";
@@ -2660,6 +2663,7 @@
 				02ACBBCB16713F2B00BB4414 /* MercatorTileLayer.m in Sources */,
 				02ACBBCC16713F2B00BB4414 /* OsmMapData.m in Sources */,
 				027EDC71206F3EED00D349D6 /* DDXMLElementAdditions.m in Sources */,
+				64CCF4D623C0B6B8006164D3 /* QuestListViewModel.swift in Sources */,
 				02BF745420793F0A0028ED6A /* TurnRestrictController.m in Sources */,
 				02ACBBCD16713F2B00BB4414 /* OsmObjects.m in Sources */,
 				02ACBCF816713F2B00BB4414 /* QuadMap.m in Sources */,

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -2988,7 +2988,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = CH829V2QQB;
 				DISPLAY_NAME = "Completionist Debug";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -3017,7 +3017,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = CH829V2QQB;
 				DISPLAY_NAME = Completionist;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -529,6 +529,7 @@
 		64CCF4DF23C0BEC0006164D3 /* StaticQuestProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4DE23C0BEC0006164D3 /* StaticQuestProvider.swift */; };
 		64CCF4E123C0C04C006164D3 /* QuestProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4E023C0C04C006164D3 /* QuestProviderMock.swift */; };
 		64CCF4E323C0C1BF006164D3 /* Quest+MakeQuest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4E223C0C1BF006164D3 /* Quest+MakeQuest.swift */; };
+		64CCF4E523C0DC2E006164D3 /* StaticQuestProviderTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4E423C0DC2E006164D3 /* StaticQuestProviderTestCase.swift */; };
 		64D64CE2227ECEA20040C67A /* OsmBaseObject+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */; };
 		64D64CE9227ECF450040C67A /* BaseObjectMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */; };
 		64D64CEC227ED0790040C67A /* KeyExistsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */; };
@@ -1188,6 +1189,7 @@
 		64CCF4DE23C0BEC0006164D3 /* StaticQuestProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticQuestProvider.swift; sourceTree = "<group>"; };
 		64CCF4E023C0C04C006164D3 /* QuestProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestProviderMock.swift; sourceTree = "<group>"; };
 		64CCF4E223C0C1BF006164D3 /* Quest+MakeQuest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Quest+MakeQuest.swift"; sourceTree = "<group>"; };
+		64CCF4E423C0DC2E006164D3 /* StaticQuestProviderTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticQuestProviderTestCase.swift; sourceTree = "<group>"; };
 		64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OsmBaseObject+Make.swift"; sourceTree = "<group>"; };
 		64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObjectMatching.swift; sourceTree = "<group>"; };
 		64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyExistsQuery.swift; sourceTree = "<group>"; };
@@ -2070,6 +2072,7 @@
 				64972EA122822BDB00286157 /* QuestManagerTestCase.swift */,
 				64972EAA22858FDF00286157 /* MapViewQuestAnnotationManagerTestCase.swift */,
 				64CCF4D823C0B708006164D3 /* QuestListViewModelTestCase.swift */,
+				64CCF4E423C0DC2E006164D3 /* StaticQuestProviderTestCase.swift */,
 			);
 			path = Overpass;
 			sourceTree = "<group>";
@@ -2787,6 +2790,7 @@
 				64972EAB22858FDF00286157 /* MapViewQuestAnnotationManagerTestCase.swift in Sources */,
 				64D64D05227ED75A0040C67A /* OverpassQueryParserTestCase.swift in Sources */,
 				64CCF4E323C0C1BF006164D3 /* Quest+MakeQuest.swift in Sources */,
+				64CCF4E523C0DC2E006164D3 /* StaticQuestProviderTestCase.swift in Sources */,
 				64348CFB225E867800ADE7FB /* HeadingProviderMock.swift in Sources */,
 				64E21EB822651F2D004605D7 /* XCTestCase+UserDefaults.swift in Sources */,
 				64D64CE2227ECEA20040C67A /* OsmBaseObject+Make.swift in Sources */,

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 		64C072FA226227D500598078 /* CommonTagKeyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C072F9226227D500598078 /* CommonTagKeyTestCase.swift */; };
 		64C072FE22622B9C00598078 /* Require.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C072FD22622B9C00598078 /* Require.swift */; };
 		64C968452261ED3100351C0C /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 64C968442261ED3100351C0C /* Media.xcassets */; };
+		64CCF4CF23C0B052006164D3 /* QuestListUITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4CE23C0B052006164D3 /* QuestListUITestCase.swift */; };
 		64CCF4D323C0B182006164D3 /* QuestListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4D123C0B182006164D3 /* QuestListTableViewController.swift */; };
 		64CCF4D423C0B182006164D3 /* QuestListTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */; };
 		64D64CE2227ECEA20040C67A /* OsmBaseObject+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */; };
@@ -1170,6 +1171,7 @@
 		64C072F9226227D500598078 /* CommonTagKeyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonTagKeyTestCase.swift; sourceTree = "<group>"; };
 		64C072FD22622B9C00598078 /* Require.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Require.swift; sourceTree = "<group>"; };
 		64C968442261ED3100351C0C /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
+		64CCF4CE23C0B052006164D3 /* QuestListUITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListUITestCase.swift; sourceTree = "<group>"; };
 		64CCF4D123C0B182006164D3 /* QuestListTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListTableViewController.swift; sourceTree = "<group>"; };
 		64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuestListTableViewController.xib; sourceTree = "<group>"; };
 		64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OsmBaseObject+Make.swift"; sourceTree = "<group>"; };
@@ -1968,6 +1970,7 @@
 				64348D0C225EA24E00ADE7FB /* Info.plist */,
 				64348D12225EAA5D00ADE7FB /* MapViewUITestCase.swift */,
 				64D64D222280B9EF0040C67A /* OverpassQueryFormUITestCase.swift */,
+				64CCF4CE23C0B052006164D3 /* QuestListUITestCase.swift */,
 			);
 			path = GoMapUITests;
 			sourceTree = "<group>";
@@ -2781,6 +2784,7 @@
 				64972EA0228227B400286157 /* XCUIApplication+TestHelper.swift in Sources */,
 				64D64D232280B9EF0040C67A /* OverpassQueryFormUITestCase.swift in Sources */,
 				64338B07235B4357006EE896 /* SnapshotHelper.swift in Sources */,
+				64CCF4CF23C0B052006164D3 /* QuestListUITestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -519,6 +519,8 @@
 		64C072FA226227D500598078 /* CommonTagKeyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C072F9226227D500598078 /* CommonTagKeyTestCase.swift */; };
 		64C072FE22622B9C00598078 /* Require.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C072FD22622B9C00598078 /* Require.swift */; };
 		64C968452261ED3100351C0C /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 64C968442261ED3100351C0C /* Media.xcassets */; };
+		64CCF4D323C0B182006164D3 /* QuestListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4D123C0B182006164D3 /* QuestListTableViewController.swift */; };
+		64CCF4D423C0B182006164D3 /* QuestListTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */; };
 		64D64CE2227ECEA20040C67A /* OsmBaseObject+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */; };
 		64D64CE9227ECF450040C67A /* BaseObjectMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */; };
 		64D64CEC227ED0790040C67A /* KeyExistsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */; };
@@ -1168,6 +1170,8 @@
 		64C072F9226227D500598078 /* CommonTagKeyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonTagKeyTestCase.swift; sourceTree = "<group>"; };
 		64C072FD22622B9C00598078 /* Require.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Require.swift; sourceTree = "<group>"; };
 		64C968442261ED3100351C0C /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
+		64CCF4D123C0B182006164D3 /* QuestListTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListTableViewController.swift; sourceTree = "<group>"; };
+		64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuestListTableViewController.xib; sourceTree = "<group>"; };
 		64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OsmBaseObject+Make.swift"; sourceTree = "<group>"; };
 		64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObjectMatching.swift; sourceTree = "<group>"; };
 		64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyExistsQuery.swift; sourceTree = "<group>"; };
@@ -1999,9 +2003,19 @@
 			path = Vendor;
 			sourceTree = "<group>";
 		};
+		64CCF4D023C0B152006164D3 /* QuestList */ = {
+			isa = PBXGroup;
+			children = (
+				64CCF4D123C0B182006164D3 /* QuestListTableViewController.swift */,
+				64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */,
+			);
+			path = QuestList;
+			sourceTree = "<group>";
+		};
 		64D64CE6227ECF450040C67A /* Overpass */ = {
 			isa = PBXGroup;
 			children = (
+				64CCF4D023C0B152006164D3 /* QuestList */,
 				64D64D1D2280B5020040C67A /* QueryForm */,
 				64D64CFF227ED5EB0040C67A /* overpass-query-parser.js */,
 				64D64D02227ED7470040C67A /* OverpassQueryParser.swift */,
@@ -2370,6 +2384,7 @@
 				02ACBC5716713F2B00BB4414 /* power_station_coal.p.64.png in Resources */,
 				02ACBC5816713F2B00BB4414 /* power_station_gas.p.64.png in Resources */,
 				02ACBC5916713F2B00BB4414 /* power_station_solar.p.64.png in Resources */,
+				64CCF4D423C0B182006164D3 /* QuestListTableViewController.xib in Resources */,
 				02ACBC5A16713F2B00BB4414 /* power_station_water.p.64.png in Resources */,
 				02ACBC5B16713F2B00BB4414 /* power_station_wind.p.64.png in Resources */,
 				02072AD41BD454E800F1CAB4 /* 751-eye-toolbar@3x.png in Resources */,
@@ -2713,6 +2728,7 @@
 				024ADF3C16B1B38B00875658 /* PathUtil.m in Sources */,
 				02CB5B6516BF1F9C00432914 /* AutocompleteTextField.m in Sources */,
 				02F04AD21BC4D3B50044FD95 /* GpxConfigureViewController.m in Sources */,
+				64CCF4D323C0B182006164D3 /* QuestListTableViewController.swift in Sources */,
 				0260484219E66C8700415CB1 /* DisplayLink.m in Sources */,
 				027EDC70206F3EED00D349D6 /* DDXMLElement.m in Sources */,
 				6442666722540EDF00C0D545 /* Lock.swift in Sources */,

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -525,6 +525,7 @@
 		64CCF4D623C0B6B8006164D3 /* QuestListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4D523C0B6B8006164D3 /* QuestListViewModel.swift */; };
 		64CCF4D923C0B708006164D3 /* QuestListViewModelTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4D823C0B708006164D3 /* QuestListViewModelTestCase.swift */; };
 		64CCF4DB23C0B8D0006164D3 /* Quest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4DA23C0B8D0006164D3 /* Quest.swift */; };
+		64CCF4DD23C0BDDF006164D3 /* QuestProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4DC23C0BDDF006164D3 /* QuestProviding.swift */; };
 		64D64CE2227ECEA20040C67A /* OsmBaseObject+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */; };
 		64D64CE9227ECF450040C67A /* BaseObjectMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */; };
 		64D64CEC227ED0790040C67A /* KeyExistsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */; };
@@ -1180,6 +1181,7 @@
 		64CCF4D523C0B6B8006164D3 /* QuestListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListViewModel.swift; sourceTree = "<group>"; };
 		64CCF4D823C0B708006164D3 /* QuestListViewModelTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListViewModelTestCase.swift; sourceTree = "<group>"; };
 		64CCF4DA23C0B8D0006164D3 /* Quest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quest.swift; sourceTree = "<group>"; };
+		64CCF4DC23C0BDDF006164D3 /* QuestProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestProviding.swift; sourceTree = "<group>"; };
 		64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OsmBaseObject+Make.swift"; sourceTree = "<group>"; };
 		64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObjectMatching.swift; sourceTree = "<group>"; };
 		64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyExistsQuery.swift; sourceTree = "<group>"; };
@@ -2018,6 +2020,7 @@
 				64CCF4D123C0B182006164D3 /* QuestListTableViewController.swift */,
 				64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */,
 				64CCF4D523C0B6B8006164D3 /* QuestListViewModel.swift */,
+				64CCF4DC23C0BDDF006164D3 /* QuestProviding.swift */,
 			);
 			path = QuestList;
 			sourceTree = "<group>";
@@ -2735,6 +2738,7 @@
 				0259E4081BCAEC88006C354C /* MyApplication.m in Sources */,
 				022ABCA120C1AACF002D4977 /* MultilineTableViewCell.m in Sources */,
 				02F371B416A4F3E6003E9548 /* HelpViewController.m in Sources */,
+				64CCF4DD23C0BDDF006164D3 /* QuestProviding.swift in Sources */,
 				640B0B752285EAA800D0EE24 /* EditorMapLayer.swift in Sources */,
 				02FFCE0B16A7360B001A5B8A /* NSMutableArray+PartialSort.mm in Sources */,
 				027EDC73206F3EED00D349D6 /* DDXMLDocument.m in Sources */,

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -527,6 +527,7 @@
 		64CCF4DB23C0B8D0006164D3 /* Quest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4DA23C0B8D0006164D3 /* Quest.swift */; };
 		64CCF4DD23C0BDDF006164D3 /* QuestProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4DC23C0BDDF006164D3 /* QuestProviding.swift */; };
 		64CCF4DF23C0BEC0006164D3 /* StaticQuestProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4DE23C0BEC0006164D3 /* StaticQuestProvider.swift */; };
+		64CCF4E123C0C04C006164D3 /* QuestProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4E023C0C04C006164D3 /* QuestProviderMock.swift */; };
 		64D64CE2227ECEA20040C67A /* OsmBaseObject+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */; };
 		64D64CE9227ECF450040C67A /* BaseObjectMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */; };
 		64D64CEC227ED0790040C67A /* KeyExistsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */; };
@@ -1184,6 +1185,7 @@
 		64CCF4DA23C0B8D0006164D3 /* Quest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quest.swift; sourceTree = "<group>"; };
 		64CCF4DC23C0BDDF006164D3 /* QuestProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestProviding.swift; sourceTree = "<group>"; };
 		64CCF4DE23C0BEC0006164D3 /* StaticQuestProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticQuestProvider.swift; sourceTree = "<group>"; };
+		64CCF4E023C0C04C006164D3 /* QuestProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestProviderMock.swift; sourceTree = "<group>"; };
 		64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OsmBaseObject+Make.swift"; sourceTree = "<group>"; };
 		64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObjectMatching.swift; sourceTree = "<group>"; };
 		64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyExistsQuery.swift; sourceTree = "<group>"; };
@@ -1969,6 +1971,7 @@
 				64972E9822820ACD00286157 /* QueryFormViewModelDelegateMock.swift */,
 				64972EA3228230F000286157 /* QuestManagerMock.swift */,
 				64D64CED227ED11F0040C67A /* BaseObjectMatcherMock.swift */,
+				64CCF4E023C0C04C006164D3 /* QuestProviderMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2771,6 +2774,7 @@
 				64D64CF8227ED2480040C67A /* KeyExistsQueryTestCase.swift in Sources */,
 				64D64CEE227ED11F0040C67A /* BaseObjectMatcherMock.swift in Sources */,
 				64972EA222822BDB00286157 /* QuestManagerTestCase.swift in Sources */,
+				64CCF4E123C0C04C006164D3 /* QuestProviderMock.swift in Sources */,
 				64972EA4228230F000286157 /* QuestManagerMock.swift in Sources */,
 				64348CFC225E867800ADE7FB /* MeasureDirectionViewModelDelegateMock.swift in Sources */,
 				64348CED225E7CD900ADE7FB /* GoMapTests.swift in Sources */,

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 		64CCF4D423C0B182006164D3 /* QuestListTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */; };
 		64CCF4D623C0B6B8006164D3 /* QuestListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4D523C0B6B8006164D3 /* QuestListViewModel.swift */; };
 		64CCF4D923C0B708006164D3 /* QuestListViewModelTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4D823C0B708006164D3 /* QuestListViewModelTestCase.swift */; };
+		64CCF4DB23C0B8D0006164D3 /* Quest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CCF4DA23C0B8D0006164D3 /* Quest.swift */; };
 		64D64CE2227ECEA20040C67A /* OsmBaseObject+Make.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */; };
 		64D64CE9227ECF450040C67A /* BaseObjectMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */; };
 		64D64CEC227ED0790040C67A /* KeyExistsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */; };
@@ -1178,6 +1179,7 @@
 		64CCF4D223C0B182006164D3 /* QuestListTableViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuestListTableViewController.xib; sourceTree = "<group>"; };
 		64CCF4D523C0B6B8006164D3 /* QuestListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListViewModel.swift; sourceTree = "<group>"; };
 		64CCF4D823C0B708006164D3 /* QuestListViewModelTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListViewModelTestCase.swift; sourceTree = "<group>"; };
+		64CCF4DA23C0B8D0006164D3 /* Quest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quest.swift; sourceTree = "<group>"; };
 		64D64CE1227ECEA20040C67A /* OsmBaseObject+Make.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OsmBaseObject+Make.swift"; sourceTree = "<group>"; };
 		64D64CE8227ECF450040C67A /* BaseObjectMatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObjectMatching.swift; sourceTree = "<group>"; };
 		64D64CEB227ED0790040C67A /* KeyExistsQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyExistsQuery.swift; sourceTree = "<group>"; };
@@ -2030,6 +2032,7 @@
 				64D64CE7227ECF450040C67A /* Queries */,
 				64972E9C22821AE300286157 /* QuestManager.swift */,
 				64972EA822858C9000286157 /* MapViewQuestAnnotationManager.swift */,
+				64CCF4DA23C0B8D0006164D3 /* Quest.swift */,
 			);
 			path = Overpass;
 			sourceTree = "<group>";
@@ -2710,6 +2713,7 @@
 				02DBB4451A1C884F00732D53 /* HeightViewController.m in Sources */,
 				02B69D101BF5A66B002605A3 /* LanguageTableViewController.m in Sources */,
 				02BED98A168B6F2F00357B94 /* WebPageViewController.m in Sources */,
+				64CCF4DB23C0B8D0006164D3 /* Quest.swift in Sources */,
 				64D64D16227F3C200040C67A /* RegularExpressionQuery.swift in Sources */,
 				02BED98E168BF87200357B94 /* NearbyMappersViewController.m in Sources */,
 				02C3C73719A5D679003B6783 /* AerialEditViewController.m in Sources */,

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -501,6 +501,7 @@
 		6442666722540EDF00C0D545 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6442666422540EDF00C0D545 /* Lock.swift */; };
 		6442666822540EDF00C0D545 /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6442666522540EDF00C0D545 /* Disposable.swift */; };
 		6442666922540EDF00C0D545 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6442666622540EDF00C0D545 /* Observable.swift */; };
+		6470F70723C21587003A463A /* Quest+staticQuests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6470F70623C21587003A463A /* Quest+staticQuests.swift */; };
 		647F46CE2253EA4C00CEC482 /* MeasureDirectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F46CD2253EA4C00CEC482 /* MeasureDirectionViewModel.swift */; };
 		647F46D12253F08200CEC482 /* HeadingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F46D02253F08200CEC482 /* HeadingProvider.swift */; };
 		64972E9922820ACD00286157 /* QueryFormViewModelDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64972E9822820ACD00286157 /* QueryFormViewModelDelegateMock.swift */; };
@@ -1162,6 +1163,7 @@
 		6442666422540EDF00C0D545 /* Lock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		6442666522540EDF00C0D545 /* Disposable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Disposable.swift; sourceTree = "<group>"; };
 		6442666622540EDF00C0D545 /* Observable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
+		6470F70623C21587003A463A /* Quest+staticQuests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Quest+staticQuests.swift"; sourceTree = "<group>"; };
 		647F46CD2253EA4C00CEC482 /* MeasureDirectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureDirectionViewModel.swift; sourceTree = "<group>"; };
 		647F46D02253F08200CEC482 /* HeadingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadingProvider.swift; sourceTree = "<group>"; };
 		64972E9822820ACD00286157 /* QueryFormViewModelDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryFormViewModelDelegateMock.swift; sourceTree = "<group>"; };
@@ -2049,6 +2051,7 @@
 				64972E9C22821AE300286157 /* QuestManager.swift */,
 				64972EA822858C9000286157 /* MapViewQuestAnnotationManager.swift */,
 				64CCF4DA23C0B8D0006164D3 /* Quest.swift */,
+				6470F70623C21587003A463A /* Quest+staticQuests.swift */,
 			);
 			path = Overpass;
 			sourceTree = "<group>";
@@ -2757,6 +2760,7 @@
 				640B0B752285EAA800D0EE24 /* EditorMapLayer.swift in Sources */,
 				02FFCE0B16A7360B001A5B8A /* NSMutableArray+PartialSort.mm in Sources */,
 				027EDC73206F3EED00D349D6 /* DDXMLDocument.m in Sources */,
+				6470F70723C21587003A463A /* Quest+staticQuests.swift in Sources */,
 				028F504519B949780093C423 /* CommonTagList.m in Sources */,
 				64CCF4DF23C0BEC0006164D3 /* StaticQuestProvider.swift in Sources */,
 				024ADF3C16B1B38B00875658 /* PathUtil.m in Sources */,

--- a/src/iOS/GoMapTests/Helpers/Quest+MakeQuest.swift
+++ b/src/iOS/GoMapTests/Helpers/Quest+MakeQuest.swift
@@ -1,0 +1,17 @@
+//
+//  Quest+MakeQuest.swift
+//  GoMapTests
+//
+//  Created by Wolfgang Timme on 1/4/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+@testable import Go_Map__
+
+extension Quest {
+    /// Convenience method for creating a `Quest` for testing
+    static func makeQuest() -> Quest {
+        return Quest(question: "Lorem ipsum?",
+                     overpassWizardQuery: "dolor_sit:amet")
+    }
+}

--- a/src/iOS/GoMapTests/Helpers/Quest+MakeQuest.swift
+++ b/src/iOS/GoMapTests/Helpers/Quest+MakeQuest.swift
@@ -10,9 +10,11 @@
 
 extension Quest {
     /// Convenience method for creating a `Quest` for testing
-    static func makeQuest(question: String = "Lorem ipsum?",
+    static func makeQuest(identifier: String = UUID().uuidString,
+                          question: String = "Lorem ipsum?",
                           overpassWizardQuery: String = "dolor_sit:amet") -> Quest {
-        return Quest(question: question,
+        return Quest(identifier: identifier,
+                     question: question,
                      overpassWizardQuery: overpassWizardQuery)
     }
 }

--- a/src/iOS/GoMapTests/Helpers/Quest+MakeQuest.swift
+++ b/src/iOS/GoMapTests/Helpers/Quest+MakeQuest.swift
@@ -10,8 +10,9 @@
 
 extension Quest {
     /// Convenience method for creating a `Quest` for testing
-    static func makeQuest() -> Quest {
-        return Quest(question: "Lorem ipsum?",
-                     overpassWizardQuery: "dolor_sit:amet")
+    static func makeQuest(question: String = "Lorem ipsum?",
+                          overpassWizardQuery: String = "dolor_sit:amet") -> Quest {
+        return Quest(question: question,
+                     overpassWizardQuery: overpassWizardQuery)
     }
 }

--- a/src/iOS/GoMapTests/Info.plist
+++ b/src/iOS/GoMapTests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 </dict>
 </plist>

--- a/src/iOS/GoMapTests/Mocks/OverpassQueryParserMock.swift
+++ b/src/iOS/GoMapTests/Mocks/OverpassQueryParserMock.swift
@@ -11,7 +11,7 @@ import Foundation
 
 class OverpassQueryParserMock: NSObject {
     var parseCallCounter = 0
-    var query: String?
+    var queries = [String]()
     var mockedResult: OverpassQueryParserResult = .success(BaseObjectMatcherMock())
 }
 
@@ -19,7 +19,7 @@ extension OverpassQueryParserMock: OverpassQueryParsing {
     
     func parse(_ query: String) -> OverpassQueryParserResult {
         parseCallCounter += 1
-        self.query = query
+        queries.append(query)
         
         return mockedResult
     }

--- a/src/iOS/GoMapTests/Mocks/QuestListViewModelDelegateMock.swift
+++ b/src/iOS/GoMapTests/Mocks/QuestListViewModelDelegateMock.swift
@@ -1,0 +1,20 @@
+//
+//  QuestListViewModelDelegateMock.swift
+//  GoMapTests
+//
+//  Created by Wolfgang Timme on 1/4/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+import Foundation
+@testable import Go_Map__
+
+class QuestListViewModelDelegateMock: QuestListViewModelDelegate {
+    private(set) var reloadItemCalled = false
+    private(set) var reloadItemIndex: Int?
+    
+    func reloadItem(at index: Int) {
+        reloadItemCalled = true
+        reloadItemIndex = index
+    }
+}

--- a/src/iOS/GoMapTests/Mocks/QuestProviderMock.swift
+++ b/src/iOS/GoMapTests/Mocks/QuestProviderMock.swift
@@ -21,4 +21,11 @@ class QuestProviderMock: QuestProviding {
         
         return isQuestActiveMockedReturnValue
     }
+    
+    var activateQuestCalled = false
+    var activateQuestQuest: Quest?
+    func activateQuest(_ quest: Quest) {
+        activateQuestCalled = true
+        activateQuestQuest = quest
+    }
 }

--- a/src/iOS/GoMapTests/Mocks/QuestProviderMock.swift
+++ b/src/iOS/GoMapTests/Mocks/QuestProviderMock.swift
@@ -28,4 +28,11 @@ class QuestProviderMock: QuestProviding {
         activateQuestCalled = true
         activateQuestQuest = quest
     }
+    
+    var deactivateQuestCalled = false
+    var deactivateQuestQuest: Quest?
+    func deactivateQuest(_ quest: Quest) {
+        deactivateQuestCalled = true
+        deactivateQuestQuest = quest
+    }
 }

--- a/src/iOS/GoMapTests/Mocks/QuestProviderMock.swift
+++ b/src/iOS/GoMapTests/Mocks/QuestProviderMock.swift
@@ -11,6 +11,7 @@ import Foundation
 
 class QuestProviderMock: QuestProviding {
     var quests = [Quest]()
+    var activeQuests = [Quest]()
     
     private(set) var isQuestActiveCalled = false
     private(set) var isQuestActiveQuest: Quest?

--- a/src/iOS/GoMapTests/Mocks/QuestProviderMock.swift
+++ b/src/iOS/GoMapTests/Mocks/QuestProviderMock.swift
@@ -1,0 +1,14 @@
+//
+//  QuestProviderMock.swift
+//  GoMapTests
+//
+//  Created by Wolfgang Timme on 1/4/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+import Foundation
+@testable import Go_Map__
+
+class QuestProviderMock: QuestProviding {
+    var quests = [Quest]()
+}

--- a/src/iOS/GoMapTests/Mocks/QuestProviderMock.swift
+++ b/src/iOS/GoMapTests/Mocks/QuestProviderMock.swift
@@ -11,4 +11,14 @@ import Foundation
 
 class QuestProviderMock: QuestProviding {
     var quests = [Quest]()
+    
+    private(set) var isQuestActiveCalled = false
+    private(set) var isQuestActiveQuest: Quest?
+    var isQuestActiveMockedReturnValue = false
+    func isQuestActive(_ quest: Quest) -> Bool {
+        isQuestActiveCalled = true
+        isQuestActiveQuest = quest
+        
+        return isQuestActiveMockedReturnValue
+    }
 }

--- a/src/iOS/GoMapTests/Overpass/MapViewQuestAnnotationManagerTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/MapViewQuestAnnotationManagerTestCase.swift
@@ -129,5 +129,91 @@ class MapViewQuestAnnotationManagerTestCase: XCTestCase {
         
         XCTAssertEqual(matcher.object, object)
     }
+    
+    // MARK: Initial loading of quests
+    
+    func testManager_whenInitialized_shouldAskParserToParseQueriesOfActiveQuests() {
+        /// Given
+        let firstQuery = "man_made = surveillance"
+        let secondQuery = "backrest is null"
+        questProviderMock.activeQuests = [Quest.makeQuest(overpassWizardQuery: firstQuery),
+                                           Quest.makeQuest(overpassWizardQuery: secondQuery)]
+
+        /// When
+        setupManager()
+
+        /// Then
+        XCTAssertEqual(queryParserMock.queries, [firstQuery, secondQuery],
+                       "The annotation manager should've asked the parser to parse the queries")
+    }
+    
+    func testManager_whenInitialized_shouldUseTheMatchersTheParserReturnedForTheActiveQuests() {
+        /// Given
+        questProviderMock.activeQuests = [Quest.makeQuest(overpassWizardQuery: "backrest is null")]
+        questManagerMock.activeQuestQuery = "man_made = surveillance"
+        
+        let firstMatcher = BaseObjectMatcherMock()
+        queryParserMock.mockedResult = .success(firstMatcher)
+        
+        let object = OsmBaseObject()
+        
+        /// During initialization, the manager will parse the quests provided by the `QuestProviding` object.
+        setupManager()
+        
+        /// Create a second matcher that will be returned when the `MapViewQuestAnnotationManager` asks the parser
+        /// to parse the `QuestManager`'s `activeQuestQuery`.
+        /// We do this in order to make sure that the `MapViewQuestAnnotationManager` uses _both_ matchers.
+        let secondMatcher = BaseObjectMatcherMock()
+        queryParserMock.mockedResult = .success(secondMatcher)
+        
+        /// When
+        _ = manager.shouldShowQuestAnnotation(for: object)
+        
+        /// Then
+        XCTAssertEqual(firstMatcher.object, object,
+                       "The annotation manager should've checked the object against the first matcher")
+    }
+    
+    // MARK: QuestManagerDidUpdateActiveQuests notification
+    
+    func testManager_whenReceivingQuestManagerDidUpdateActiveQuestsNotification_shouldAskParserToParseQueriesOfActiveQuests() {
+        /// Given
+        let firstQuery = "man_made = surveillance"
+        let secondQuery = "backrest is null"
+        questProviderMock.activeQuests = [Quest.makeQuest(overpassWizardQuery: firstQuery),
+                                          Quest.makeQuest(overpassWizardQuery: secondQuery)]
+        
+        /// When
+        notificationCenter.post(name: .QuestManagerDidUpdateActiveQuests,
+                                object: questProviderMock)
+        
+        /// Then
+        XCTAssertEqual(queryParserMock.queries, [firstQuery, secondQuery],
+                       "The annotation manager should've asked the parser to parse the queries")
+    }
+    
+    func testManager_whenReceivingQuestManagerDidUpdateActiveQuestsNotification_shouldUseTheMatchersTheParserReturnedForTheActiveQuests() {
+        /// Given
+        let object = OsmBaseObject()
+        
+        /// During initialization, the manager will parse the quests provided by the `QuestProviding` object.
+        setupManager()
+        
+        /// Create a matcher _after_ initialization.
+        /// We do this in order to make sure that the `MapViewQuestAnnotationManager` uses that one after receiving the notification.
+        let matcher = BaseObjectMatcherMock()
+        queryParserMock.mockedResult = .success(matcher)
+        
+        questProviderMock.activeQuests = [Quest.makeQuest(overpassWizardQuery: "backrest is null")]
+        notificationCenter.post(name: .QuestManagerDidUpdateActiveQuests,
+                                object: questProviderMock)
+        
+        /// When
+        _ = manager.shouldShowQuestAnnotation(for: object)
+        
+        /// Then
+        XCTAssertEqual(matcher.object, object,
+                       "The annotation manager should've checked the object against the matcher")
+    }
 
 }

--- a/src/iOS/GoMapTests/Overpass/MapViewQuestAnnotationManagerTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/MapViewQuestAnnotationManagerTestCase.swift
@@ -14,14 +14,17 @@ class MapViewQuestAnnotationManagerTestCase: XCTestCase {
     
     var manager: MapViewQuestAnnotationManaging!
     var questManagerMock: QuestManagerMock!
+    var questProviderMock: QuestProviderMock!
     var queryParserMock: OverpassQueryParserMock!
 
     override func setUp() {
         super.setUp()
         
         questManagerMock = QuestManagerMock()
+        questProviderMock = QuestProviderMock()
         queryParserMock = OverpassQueryParserMock()
         manager = MapViewQuestAnnotationManager(questManager: questManagerMock,
+                                                questProvider: questProviderMock,
                                                 queryParser: queryParserMock)
     }
 

--- a/src/iOS/GoMapTests/Overpass/MapViewQuestAnnotationManagerTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/MapViewQuestAnnotationManagerTestCase.swift
@@ -40,6 +40,8 @@ class MapViewQuestAnnotationManagerTestCase: XCTestCase {
         super.tearDown()
     }
     
+    // MARK: shouldShowQuestAnnotation(for:)
+    
     func testShowAnnotationWithoutActiveQueryShouldNotAskParserToParse() {
         let query: String? = nil
         questManagerMock.activeQuestQuery = query

--- a/src/iOS/GoMapTests/Overpass/MapViewQuestAnnotationManagerTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/MapViewQuestAnnotationManagerTestCase.swift
@@ -54,7 +54,7 @@ class MapViewQuestAnnotationManagerTestCase: XCTestCase {
         _ = manager.shouldShowQuestAnnotation(for: object)
         
         XCTAssertEqual(queryParserMock.parseCallCounter, 1)
-        XCTAssertEqual(queryParserMock.query, query)
+        XCTAssertEqual(queryParserMock.queries.first, query)
     }
     
     func testShowAnnotationWithActiveQueryThatIsValidShouldOnlyAskParserToParseIfQueryWasChanged() {

--- a/src/iOS/GoMapTests/Overpass/MapViewQuestAnnotationManagerTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/MapViewQuestAnnotationManagerTestCase.swift
@@ -25,10 +25,8 @@ class MapViewQuestAnnotationManagerTestCase: XCTestCase {
         questProviderMock = QuestProviderMock()
         queryParserMock = OverpassQueryParserMock()
         notificationCenter = NotificationCenter()
-        manager = MapViewQuestAnnotationManager(questManager: questManagerMock,
-                                                questProvider: questProviderMock,
-                                                queryParser: queryParserMock,
-                                                notificationCenter: notificationCenter)
+        
+        setupManager()
     }
 
     override func tearDown() {
@@ -38,6 +36,15 @@ class MapViewQuestAnnotationManagerTestCase: XCTestCase {
         notificationCenter = nil
         
         super.tearDown()
+    }
+    
+    // MARK: Private methods
+    
+    private func setupManager() {
+        manager = MapViewQuestAnnotationManager(questManager: questManagerMock,
+                                                questProvider: questProviderMock,
+                                                queryParser: queryParserMock,
+                                                notificationCenter: notificationCenter)
     }
     
     // MARK: shouldShowQuestAnnotation(for:)

--- a/src/iOS/GoMapTests/Overpass/MapViewQuestAnnotationManagerTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/MapViewQuestAnnotationManagerTestCase.swift
@@ -16,6 +16,7 @@ class MapViewQuestAnnotationManagerTestCase: XCTestCase {
     var questManagerMock: QuestManagerMock!
     var questProviderMock: QuestProviderMock!
     var queryParserMock: OverpassQueryParserMock!
+    var notificationCenter: NotificationCenter!
 
     override func setUp() {
         super.setUp()
@@ -23,15 +24,18 @@ class MapViewQuestAnnotationManagerTestCase: XCTestCase {
         questManagerMock = QuestManagerMock()
         questProviderMock = QuestProviderMock()
         queryParserMock = OverpassQueryParserMock()
+        notificationCenter = NotificationCenter()
         manager = MapViewQuestAnnotationManager(questManager: questManagerMock,
                                                 questProvider: questProviderMock,
-                                                queryParser: queryParserMock)
+                                                queryParser: queryParserMock,
+                                                notificationCenter: notificationCenter)
     }
 
     override func tearDown() {
         manager = nil
         questManagerMock = nil
         queryParserMock = nil
+        notificationCenter = nil
         
         super.tearDown()
     }

--- a/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
@@ -28,5 +28,15 @@ class QuestListViewModelTestCase: XCTestCase {
         
         super.tearDown()
     }
+    
+    // MARK: numberOfItems
+    
+    func testNumberOfItems_shouldMatchTheNumberOfQuests() {
+        questProviderMock.quests = []
+        XCTAssertEqual(viewModel.numberOfItems(), 0)
+        
+        questProviderMock.quests = [Quest.makeQuest(), Quest.makeQuest()]
+        XCTAssertEqual(viewModel.numberOfItems(), 2)
+    }
 
 }

--- a/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
@@ -106,5 +106,74 @@ class QuestListViewModelTestCase: XCTestCase {
         let item = viewModel.item(at: 0)
         XCTAssertEqual(item?.accessory, QuestListViewModel.Item.Accessory.checkmark)
     }
+    
+    // MARK: selectItem(at:)
+    
+    func testSelectItemAtIndex_whenProvidedWithANegativeIndex_shouldNotCallQuestProvider() {
+        viewModel.selectItem(at: -1)
+        
+        XCTAssertFalse(questProviderMock.activateQuestCalled)
+        XCTAssertFalse(questProviderMock.deactivateQuestCalled)
+    }
+    
+    func testSelectItemAtIndex_whenProvidedWithAnIndexThatIsOutOfRange_shouldNotCallQuestProvider() {
+        questProviderMock.quests = [Quest.makeQuest()]
+        
+        viewModel.selectItem(at: 42)
+        
+        XCTAssertFalse(questProviderMock.activateQuestCalled)
+        XCTAssertFalse(questProviderMock.deactivateQuestCalled)
+    }
+    
+    func testSelectItemAtIndex_whenProvidedWithAValidIndex_shouldAskQuestProviderIfTheQuestAtTheGivenIndexWasActive() {
+        let firstQuest = Quest.makeQuest()
+        let secondQuest = Quest.makeQuest()
+        questProviderMock.quests = [firstQuest, secondQuest]
+        
+        viewModel.selectItem(at: 1)
+        
+        XCTAssertEqual(questProviderMock.isQuestActiveQuest?.identifier,
+                       secondQuest.identifier, "The view model should ask the quest provider if that particular quest was active")
+    }
+    
+    func testSelectItemAtIndex_whenProvidedWithAValidIndexThatTheQuestProviderReportedAsNotActive_shouldAskQuestProviderToActivateTheQuest() {
+        questProviderMock.quests = [Quest.makeQuest()]
+        questProviderMock.isQuestActiveMockedReturnValue = false
+        
+        viewModel.selectItem(at: 0)
+        
+        XCTAssertTrue(questProviderMock.activateQuestCalled)
+    }
+    
+    func testSelectItemAtIndex_whenProvidedWithAValidIndexThatTheQuestProviderReportedAsNotActive_shouldAskQuestProviderToActivateThatParticularQuest() {
+        let firstQuest = Quest.makeQuest()
+        let secondQuest = Quest.makeQuest()
+        questProviderMock.quests = [firstQuest, secondQuest]
+        questProviderMock.isQuestActiveMockedReturnValue = false
+        
+        viewModel.selectItem(at: 1)
+        
+        XCTAssertEqual(questProviderMock.activateQuestQuest?.identifier, secondQuest.identifier)
+    }
+    
+    func testSelectItemAtIndex_whenProvidedWithAValidIndexThatTheQuestProviderReportedAsActive_shouldAskQuestProviderToDeactivateTheQuest() {
+        questProviderMock.quests = [Quest.makeQuest()]
+        questProviderMock.isQuestActiveMockedReturnValue = true
+        
+        viewModel.selectItem(at: 0)
+        
+        XCTAssertTrue(questProviderMock.deactivateQuestCalled)
+    }
+    
+    func testSelectItemAtIndex_whenProvidedWithAValidIndexThatTheQuestProviderReportedAsActive_shouldAskQuestProviderToDeactivateThatParticularQuest() {
+        let firstQuest = Quest.makeQuest()
+        let secondQuest = Quest.makeQuest()
+        questProviderMock.quests = [firstQuest, secondQuest]
+        questProviderMock.isQuestActiveMockedReturnValue = true
+        
+        viewModel.selectItem(at: 1)
+        
+        XCTAssertEqual(questProviderMock.deactivateQuestQuest?.identifier, secondQuest.identifier)
+    }
 
 }

--- a/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
@@ -130,6 +130,18 @@ class QuestListViewModelTestCase: XCTestCase {
         XCTAssertFalse(questProviderMock.deactivateQuestCalled)
     }
     
+    func testSelectItemAtIndex_whenProvidedWithAValidIndex_shouldAskDelegateToReloadTheItemAtThatPath() {
+        let firstQuest = Quest.makeQuest()
+        let secondQuest = Quest.makeQuest()
+        questProviderMock.quests = [firstQuest, secondQuest]
+        
+        let itemIndex = 1
+        viewModel.selectItem(at: itemIndex)
+        
+        XCTAssertTrue(delegateMock.reloadItemCalled)
+        XCTAssertEqual(delegateMock.reloadItemIndex, itemIndex)
+    }
+    
     func testSelectItemAtIndex_whenProvidedWithAValidIndex_shouldAskQuestProviderIfTheQuestAtTheGivenIndexWasActive() {
         let firstQuest = Quest.makeQuest()
         let secondQuest = Quest.makeQuest()

--- a/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
@@ -14,17 +14,22 @@ class QuestListViewModelTestCase: XCTestCase {
     
     var viewModel: QuestListViewModel!
     var questProviderMock: QuestProviderMock!
+    var delegateMock: QuestListViewModelDelegateMock!
 
     override func setUp() {
         super.setUp()
         
         questProviderMock = QuestProviderMock()
         viewModel = QuestListViewModel(questProvider: questProviderMock)
+        
+        delegateMock = QuestListViewModelDelegateMock()
+        viewModel.delegate = delegateMock
     }
 
     override func tearDown() {
         viewModel = nil
         questProviderMock = nil
+        delegateMock = nil
         
         super.tearDown()
     }

--- a/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
@@ -13,15 +13,18 @@ import XCTest
 class QuestListViewModelTestCase: XCTestCase {
     
     var viewModel: QuestListViewModel!
+    var questProviderMock: QuestProviderMock!
 
     override func setUp() {
         super.setUp()
         
-        viewModel = QuestListViewModel()
+        questProviderMock = QuestProviderMock()
+        viewModel = QuestListViewModel(questProvider: questProviderMock)
     }
 
     override func tearDown() {
         viewModel = nil
+        questProviderMock = nil
         
         super.tearDown()
     }

--- a/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
@@ -66,5 +66,25 @@ class QuestListViewModelTestCase: XCTestCase {
         let item = viewModel.item(at: 0)
         XCTAssertEqual(item?.subtitle, overpassWizardQuery)
     }
+    
+    func testItemAtIndex_whenProvidedWithAValidIndex_shouldAskQuestProviderIfQuestWasActive() {
+        let quest = Quest.makeQuest()
+        questProviderMock.quests = [quest]
+        
+        _ = viewModel.item(at: 0)
+        
+        XCTAssertTrue(questProviderMock.isQuestActiveCalled)
+    }
+    
+    func testItemAtIndex_whenProvidedWithAValidIndex_shouldAskQuestProviderIfTheQuestAtTheGivenIndexWasActive() {
+        let firstQuest = Quest.makeQuest()
+        let secondQuest = Quest.makeQuest()
+        questProviderMock.quests = [firstQuest, secondQuest]
+        
+        _ = viewModel.item(at: 1)
+        
+        XCTAssertEqual(questProviderMock.isQuestActiveQuest?.identifier,
+                       secondQuest.identifier, "The view model should ask the quest provider if that particular quest was active")
+    }
 
 }

--- a/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
@@ -1,0 +1,29 @@
+//
+//  QuestListViewModelTestCase.swift
+//  GoMapTests
+//
+//  Created by Wolfgang Timme on 1/4/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+import XCTest
+
+@testable import Go_Map__
+
+class QuestListViewModelTestCase: XCTestCase {
+    
+    var viewModel: QuestListViewModel!
+
+    override func setUp() {
+        super.setUp()
+        
+        viewModel = QuestListViewModel()
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        
+        super.tearDown()
+    }
+
+}

--- a/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
@@ -38,5 +38,33 @@ class QuestListViewModelTestCase: XCTestCase {
         questProviderMock.quests = [Quest.makeQuest(), Quest.makeQuest()]
         XCTAssertEqual(viewModel.numberOfItems(), 2)
     }
+    
+    // MARK: item(at:)
+    
+    func testItemAtIndex_whenProvidedWithNegativeIndex_shouldReturnNil() {
+        XCTAssertNil(viewModel.item(at: -1))
+    }
+    
+    func testItemAtIndex_whenProvidedWithAnIndexThatIsOutOfRange_shouldReturnNil() {
+        questProviderMock.quests = [Quest.makeQuest()]
+        
+        XCTAssertNil(viewModel.item(at: 42))
+    }
+    
+    func testItemAtIndex_whenProvidedWithAValidIndex_shouldReturnItemWithTheQuestQuestionAsTitle() {
+        let question = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        questProviderMock.quests = [Quest(question: question, overpassWizardQuery: "")]
+        
+        let item = viewModel.item(at: 0)
+        XCTAssertEqual(item?.title, question)
+    }
+    
+    func testItemAtIndex_whenProvidedWithAValidIndex_shouldReturnItemWithTheQuestQueryAsSubtitle() {
+        let overpassWizardQuery = "type:node"
+        questProviderMock.quests = [Quest(question: "", overpassWizardQuery: overpassWizardQuery)]
+        
+        let item = viewModel.item(at: 0)
+        XCTAssertEqual(item?.subtitle, overpassWizardQuery)
+    }
 
 }

--- a/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
@@ -86,5 +86,25 @@ class QuestListViewModelTestCase: XCTestCase {
         XCTAssertEqual(questProviderMock.isQuestActiveQuest?.identifier,
                        secondQuest.identifier, "The view model should ask the quest provider if that particular quest was active")
     }
+    
+    func testItemAtIndex_whenProvidedWithAValidIndex_shouldReturnItemWithAccessoryNoneIfQuestWasNotActive() {
+        questProviderMock.quests = [Quest.makeQuest()]
+        
+        /// Act as if the quest was not active.
+        questProviderMock.isQuestActiveMockedReturnValue = false
+        
+        let item = viewModel.item(at: 0)
+        XCTAssertEqual(item?.accessory, QuestListViewModel.Item.Accessory.none)
+    }
+    
+    func testItemAtIndex_whenProvidedWithAValidIndex_shouldReturnItemWithAccessoryCheckmarkIfQuestWasActive() {
+        questProviderMock.quests = [Quest.makeQuest()]
+        
+        /// Act as if the quest was not active.
+        questProviderMock.isQuestActiveMockedReturnValue = true
+        
+        let item = viewModel.item(at: 0)
+        XCTAssertEqual(item?.accessory, QuestListViewModel.Item.Accessory.checkmark)
+    }
 
 }

--- a/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/QuestListViewModelTestCase.swift
@@ -53,7 +53,7 @@ class QuestListViewModelTestCase: XCTestCase {
     
     func testItemAtIndex_whenProvidedWithAValidIndex_shouldReturnItemWithTheQuestQuestionAsTitle() {
         let question = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        questProviderMock.quests = [Quest(question: question, overpassWizardQuery: "")]
+        questProviderMock.quests = [Quest.makeQuest(question: question)]
         
         let item = viewModel.item(at: 0)
         XCTAssertEqual(item?.title, question)
@@ -61,7 +61,7 @@ class QuestListViewModelTestCase: XCTestCase {
     
     func testItemAtIndex_whenProvidedWithAValidIndex_shouldReturnItemWithTheQuestQueryAsSubtitle() {
         let overpassWizardQuery = "type:node"
-        questProviderMock.quests = [Quest(question: "", overpassWizardQuery: overpassWizardQuery)]
+        questProviderMock.quests = [Quest.makeQuest(overpassWizardQuery: overpassWizardQuery)]
         
         let item = viewModel.item(at: 0)
         XCTAssertEqual(item?.subtitle, overpassWizardQuery)

--- a/src/iOS/GoMapTests/Overpass/QuestManagerTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/QuestManagerTestCase.swift
@@ -57,7 +57,7 @@ class QuestManagerTestCase: XCTestCase {
     func testSetActiveQuestQueryShouldPostNotification() {
         manager.activeQuestQuery = "camera:mount = pole"
         
-        let notificationExpectation = expectation(forNotification: .QuestManagerDidUpdateActiveQuest,
+        let notificationExpectation = expectation(forNotification: .QuestManagerDidUpdateActiveQuests,
                                                   object: manager,
                                                   notificationCenter: notificationCenter,
                                                   handler: nil)
@@ -70,7 +70,7 @@ class QuestManagerTestCase: XCTestCase {
     func testSetActiveQuestQueryToTheSameShouldNotPostNotification() {
         manager.activeQuestQuery = "camera:mount = pole"
         
-        let notificationExpectation = expectation(forNotification: .QuestManagerDidUpdateActiveQuest,
+        let notificationExpectation = expectation(forNotification: .QuestManagerDidUpdateActiveQuests,
                                                   object: manager,
                                                   notificationCenter: notificationCenter,
                                                   handler: nil)

--- a/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
@@ -73,5 +73,47 @@ class StaticQuestProviderTestCase: XCTestCase {
                                                       activeQuestIdentifierUserDefaultsKey: activeQuestIdentifierUserDefaultsKey)
         XCTAssertTrue(secondQuestProvider.isQuestActive(firstQuest))
     }
+    
+    // MARK: activateQuest(_:)
+    
+    func testActiveQuest_shouldStoreQuestIdentifierInUserDefaults() {
+        /// Just use the first quest as an example.
+        guard let firstQuest = questProvider.quests.first else {
+            XCTFail()
+            return
+        }
+        
+        questProvider.activateQuest(firstQuest)
+        
+        guard
+            let activeQuestIdentifiers = userDefaults.object(forKey: activeQuestIdentifierUserDefaultsKey) as? [String]
+        else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertTrue(activeQuestIdentifiers.contains(firstQuest.identifier))
+    }
+    
+    func testActiveQuest_shouldStoreQuestIdentifierInUserDefaultsOnlyOnce() {
+        /// Just use the first quest as an example.
+        guard let firstQuest = questProvider.quests.first else {
+            XCTFail()
+            return
+        }
+        
+        for _ in 1...10 {
+            questProvider.activateQuest(firstQuest)
+        }
+        
+        guard
+            let activeQuestIdentifiers = userDefaults.object(forKey: activeQuestIdentifierUserDefaultsKey) as? [String]
+        else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(activeQuestIdentifiers.filter({ $0 == firstQuest.identifier }).count, 1)
+    }
 
 }

--- a/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
@@ -121,6 +121,42 @@ class StaticQuestProviderTestCase: XCTestCase {
         XCTAssertEqual(activeQuestIdentifiers.filter({ $0 == firstQuest.identifier }).count, 1)
     }
     
+    func testActivateQuest_whenQuestWasNotActiveBefore_shouldPostNotification() {
+        /// Just use the first quest as an example.
+        guard let firstQuest = questProvider.quests.first else {
+            XCTFail()
+            return
+        }
+        
+        _ = expectation(forNotification: .QuestManagerDidUpdateActiveQuests,
+                        object: questProvider,
+                        notificationCenter: notificationCenter)
+        
+        questProvider.activateQuest(firstQuest)
+        
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
+    
+    func testActivateQuest_whenQuestWasActiveBefore_shouldNotPostNotification() {
+        /// Just use the first quest as an example.
+        guard let firstQuest = questProvider.quests.first else {
+            XCTFail()
+            return
+        }
+        
+        /// Act as if the quest was active.
+        userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
+        
+        let notificationExpectation = expectation(forNotification: .QuestManagerDidUpdateActiveQuests,
+                                                  object: questProvider,
+                                                  notificationCenter: notificationCenter)
+        notificationExpectation.isInverted = true
+        
+        questProvider.activateQuest(firstQuest)
+        
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
+    
     // MARK: deactivateQuest(_:)
     
     func testDeactiveQuest_shouldRemoveTheQuestIdentifierFromUserDefaults() {

--- a/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
@@ -13,15 +13,24 @@ import XCTest
 class StaticQuestProviderTestCase: XCTestCase {
     
     var questProvider: QuestProviding!
+    
+    var userDefaults: UserDefaults!
+    let userDefaultsSuiteName = "TestDefaults"
+    let activeQuestIdentifierUserDefaultsKey = "identifiers"
 
     override func setUp() {
         super.setUp()
         
-        questProvider = StaticQuestProvider()
+        UserDefaults().removePersistentDomain(forName: userDefaultsSuiteName)
+        userDefaults = UserDefaults(suiteName: userDefaultsSuiteName)
+        
+        questProvider = StaticQuestProvider(userDefaults: userDefaults,
+                                            activeQuestIdentifierUserDefaultsKey: activeQuestIdentifierUserDefaultsKey)
     }
 
     override func tearDown() {
         questProvider = nil
+        userDefaults = nil
         
         super.tearDown()
     }

--- a/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
@@ -27,9 +27,7 @@ class StaticQuestProviderTestCase: XCTestCase {
         
         notificationCenter = NotificationCenter()
         
-        questProvider = StaticQuestProvider(userDefaults: userDefaults,
-                                            activeQuestIdentifierUserDefaultsKey: activeQuestIdentifierUserDefaultsKey,
-                                            notificationCenter: notificationCenter)
+        setupQuestProvider()
     }
 
     override func tearDown() {
@@ -38,6 +36,14 @@ class StaticQuestProviderTestCase: XCTestCase {
         notificationCenter = nil
         
         super.tearDown()
+    }
+    
+    // MARK: Helper methods
+    
+    private func setupQuestProvider() {
+        questProvider = StaticQuestProvider(userDefaults: userDefaults,
+                                            activeQuestIdentifierUserDefaultsKey: activeQuestIdentifierUserDefaultsKey,
+                                            notificationCenter: notificationCenter)
     }
     
     // MARK: isQuestActive(_:)

--- a/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
@@ -50,44 +50,44 @@ class StaticQuestProviderTestCase: XCTestCase {
     // MARK: isQuestActive(_:)
     
     func testIsQuestActive_shouldInitiallyReturnFalse() {
-        let firstQuest = Quest.makeQuest()
-        setupQuestProvider(quests: [firstQuest])
+        let quest = Quest.makeQuest()
+        setupQuestProvider(quests: [quest])
         
-        XCTAssertFalse(questProvider.isQuestActive(firstQuest))
+        XCTAssertFalse(questProvider.isQuestActive(quest))
     }
     
     func testIsQuestActive_whenTheQuestIdentifierIsPartOfTheUserDefaults_shouldReturnTrue() {
-        let firstQuest = Quest.makeQuest()
-        setupQuestProvider(quests: [firstQuest])
+        let quest = Quest.makeQuest()
+        setupQuestProvider(quests: [quest])
         
         /// Store the identifier in the `UserDefaults`.
-        userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
+        userDefaults.set([quest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
         
-        XCTAssertTrue(questProvider.isQuestActive(firstQuest))
+        XCTAssertTrue(questProvider.isQuestActive(quest))
     }
     
     /// This method makes sure that the values are persisted in the `UserDefaults`, and that when a second `StaticQuestProvider` is initialized
     /// with the same `UserDefaults` and the same `activeQuestIdentifierUserDefaultsKey`, a `Quest` is still considered "active".
     func testIsQuestActive_whenUsingTheSameUserDefaultsAndTheSameUserDefaultsKey_shouldStillReturnTrue() {
-        let firstQuest = Quest.makeQuest()
-        setupQuestProvider(quests: [firstQuest])
+        let quest = Quest.makeQuest()
+        setupQuestProvider(quests: [quest])
         
         /// Store the identifier in the `UserDefaults`.
-        userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
+        userDefaults.set([quest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
         
         /// Create a second `StaticQuestProvider` with the same values.
         let secondQuestProvider = StaticQuestProvider(userDefaults: userDefaults,
                                                       activeQuestIdentifierUserDefaultsKey: activeQuestIdentifierUserDefaultsKey)
-        XCTAssertTrue(secondQuestProvider.isQuestActive(firstQuest))
+        XCTAssertTrue(secondQuestProvider.isQuestActive(quest))
     }
     
     // MARK: activateQuest(_:)
     
     func testActiveQuest_shouldStoreQuestIdentifierInUserDefaults() {
-        let firstQuest = Quest.makeQuest()
-        setupQuestProvider(quests: [firstQuest])
+        let quest = Quest.makeQuest()
+        setupQuestProvider(quests: [quest])
         
-        questProvider.activateQuest(firstQuest)
+        questProvider.activateQuest(quest)
         
         guard
             let activeQuestIdentifiers = userDefaults.object(forKey: activeQuestIdentifierUserDefaultsKey) as? [String]
@@ -96,15 +96,15 @@ class StaticQuestProviderTestCase: XCTestCase {
             return
         }
         
-        XCTAssertTrue(activeQuestIdentifiers.contains(firstQuest.identifier))
+        XCTAssertTrue(activeQuestIdentifiers.contains(quest.identifier))
     }
     
     func testActiveQuest_shouldStoreQuestIdentifierInUserDefaultsOnlyOnce() {
-        let firstQuest = Quest.makeQuest()
-        setupQuestProvider(quests: [firstQuest])
+        let quest = Quest.makeQuest()
+        setupQuestProvider(quests: [quest])
         
         for _ in 1...10 {
-            questProvider.activateQuest(firstQuest)
+            questProvider.activateQuest(quest)
         }
         
         guard
@@ -114,35 +114,35 @@ class StaticQuestProviderTestCase: XCTestCase {
             return
         }
         
-        XCTAssertEqual(activeQuestIdentifiers.filter({ $0 == firstQuest.identifier }).count, 1)
+        XCTAssertEqual(activeQuestIdentifiers.filter({ $0 == quest.identifier }).count, 1)
     }
     
     func testActivateQuest_whenQuestWasNotActiveBefore_shouldPostNotification() {
-        let firstQuest = Quest.makeQuest()
-        setupQuestProvider(quests: [firstQuest])
+        let quest = Quest.makeQuest()
+        setupQuestProvider(quests: [quest])
         
         _ = expectation(forNotification: .QuestManagerDidUpdateActiveQuests,
                         object: questProvider,
                         notificationCenter: notificationCenter)
         
-        questProvider.activateQuest(firstQuest)
+        questProvider.activateQuest(quest)
         
         waitForExpectations(timeout: 1.0, handler: nil)
     }
     
     func testActivateQuest_whenQuestWasActiveBefore_shouldNotPostNotification() {
-        let firstQuest = Quest.makeQuest()
-        setupQuestProvider(quests: [firstQuest])
+        let quest = Quest.makeQuest()
+        setupQuestProvider(quests: [quest])
         
         /// Act as if the quest was active.
-        userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
+        userDefaults.set([quest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
         
         let notificationExpectation = expectation(forNotification: .QuestManagerDidUpdateActiveQuests,
                                                   object: questProvider,
                                                   notificationCenter: notificationCenter)
         notificationExpectation.isInverted = true
         
-        questProvider.activateQuest(firstQuest)
+        questProvider.activateQuest(quest)
         
         waitForExpectations(timeout: 1.0, handler: nil)
     }
@@ -150,12 +150,12 @@ class StaticQuestProviderTestCase: XCTestCase {
     // MARK: deactivateQuest(_:)
     
     func testDeactiveQuest_shouldRemoveTheQuestIdentifierFromUserDefaults() {
-        let firstQuest = Quest.makeQuest()
-        setupQuestProvider(quests: [firstQuest])
+        let quest = Quest.makeQuest()
+        setupQuestProvider(quests: [quest])
         
-        userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
+        userDefaults.set([quest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
         
-        questProvider.deactivateQuest(firstQuest)
+        questProvider.deactivateQuest(quest)
         
         guard
             let activeQuestIdentifiers = userDefaults.object(forKey: activeQuestIdentifierUserDefaultsKey) as? [String]
@@ -164,35 +164,35 @@ class StaticQuestProviderTestCase: XCTestCase {
             return
         }
         
-        XCTAssertFalse(activeQuestIdentifiers.contains(firstQuest.identifier))
+        XCTAssertFalse(activeQuestIdentifiers.contains(quest.identifier))
     }
     
     func testDeactivateQuest_whenQuestWasActiveBefore_shouldPostNotification() {
-        let firstQuest = Quest.makeQuest()
-        setupQuestProvider(quests: [firstQuest])
+        let quest = Quest.makeQuest()
+        setupQuestProvider(quests: [quest])
         
         /// Act as if the quest was active.
-        userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
+        userDefaults.set([quest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
         
         _ = expectation(forNotification: .QuestManagerDidUpdateActiveQuests,
                         object: questProvider,
                         notificationCenter: notificationCenter)
         
-        questProvider.deactivateQuest(firstQuest)
+        questProvider.deactivateQuest(quest)
         
         waitForExpectations(timeout: 1.0, handler: nil)
     }
     
     func testDeactivateQuest_whenQuestWasNotActiveBefore_shouldNotPostNotification() {
-        let firstQuest = Quest.makeQuest()
-        setupQuestProvider(quests: [firstQuest])
+        let quest = Quest.makeQuest()
+        setupQuestProvider(quests: [quest])
         
         let notificationExpectation = expectation(forNotification: .QuestManagerDidUpdateActiveQuests,
                                                   object: questProvider,
                                                   notificationCenter: notificationCenter)
         notificationExpectation.isInverted = true
         
-        questProvider.deactivateQuest(firstQuest)
+        questProvider.deactivateQuest(quest)
         
         waitForExpectations(timeout: 1.0, handler: nil)
     }

--- a/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
@@ -40,8 +40,9 @@ class StaticQuestProviderTestCase: XCTestCase {
     
     // MARK: Helper methods
     
-    private func setupQuestProvider() {
-        questProvider = StaticQuestProvider(userDefaults: userDefaults,
+    private func setupQuestProvider(quests: [Quest] = [Quest.makeQuest()]) {
+        questProvider = StaticQuestProvider(quests: quests,
+                                            userDefaults: userDefaults,
                                             activeQuestIdentifierUserDefaultsKey: activeQuestIdentifierUserDefaultsKey,
                                             notificationCenter: notificationCenter)
     }

--- a/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
@@ -179,5 +179,41 @@ class StaticQuestProviderTestCase: XCTestCase {
         
         XCTAssertFalse(activeQuestIdentifiers.contains(firstQuest.identifier))
     }
+    
+    func testDeactivateQuest_whenQuestWasActiveBefore_shouldPostNotification() {
+        /// Just use the first quest as an example.
+        guard let firstQuest = questProvider.quests.first else {
+            XCTFail()
+            return
+        }
+        
+        /// Act as if the quest was active.
+        userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
+        
+        _ = expectation(forNotification: .QuestManagerDidUpdateActiveQuests,
+                        object: questProvider,
+                        notificationCenter: notificationCenter)
+        
+        questProvider.deactivateQuest(firstQuest)
+        
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
+    
+    func testDeactivateQuest_whenQuestWasNotActiveBefore_shouldNotPostNotification() {
+        /// Just use the first quest as an example.
+        guard let firstQuest = questProvider.quests.first else {
+            XCTFail()
+            return
+        }
+        
+        let notificationExpectation = expectation(forNotification: .QuestManagerDidUpdateActiveQuests,
+                                                  object: questProvider,
+                                                  notificationCenter: notificationCenter)
+        notificationExpectation.isInverted = true
+        
+        questProvider.deactivateQuest(firstQuest)
+        
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
 
 }

--- a/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
@@ -47,6 +47,36 @@ class StaticQuestProviderTestCase: XCTestCase {
                                             notificationCenter: notificationCenter)
     }
     
+    // MARK: activeQuests
+    
+    func testActiveQuests_whenQuestIdentifierIsStoredInUserDefaults_shouldReturnQuest() {
+        /// Given
+        let questIdentifier = "lorem_ipsum"
+        let quest = Quest.makeQuest(identifier: questIdentifier)
+        
+        setupQuestProvider(quests: [quest])
+        
+        /// When
+        userDefaults.set([questIdentifier], forKey: activeQuestIdentifierUserDefaultsKey)
+        
+        /// Then
+        XCTAssertTrue(questProvider.activeQuests.contains(where: { $0.identifier == questIdentifier }))
+    }
+    
+    func testActiveQuests_whenQuestIdentifierIsNotStoredInUserDefaults_shouldNotReturnQuest() {
+        /// Given
+        let questIdentifier = "lorem_ipsum"
+        let quest = Quest.makeQuest(identifier: questIdentifier)
+        
+        setupQuestProvider(quests: [quest])
+        
+        /// When
+        userDefaults.set([], forKey: activeQuestIdentifierUserDefaultsKey)
+        
+        /// Then
+        XCTAssertTrue(questProvider.activeQuests.isEmpty)
+    }
+    
     // MARK: isQuestActive(_:)
     
     func testIsQuestActive_shouldInitiallyReturnFalse() {

--- a/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
@@ -115,5 +115,28 @@ class StaticQuestProviderTestCase: XCTestCase {
         
         XCTAssertEqual(activeQuestIdentifiers.filter({ $0 == firstQuest.identifier }).count, 1)
     }
+    
+    // MARK: deactivateQuest(_:)
+    
+    func testDeactiveQuest_shouldRemoveTheQuestIdentifierFromUserDefaults() {
+        /// Just use the first quest as an example.
+        guard let firstQuest = questProvider.quests.first else {
+            XCTFail()
+            return
+        }
+        
+        userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
+        
+        questProvider.deactivateQuest(firstQuest)
+        
+        guard
+            let activeQuestIdentifiers = userDefaults.object(forKey: activeQuestIdentifierUserDefaultsKey) as? [String]
+        else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertFalse(activeQuestIdentifiers.contains(firstQuest.identifier))
+    }
 
 }

--- a/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
@@ -49,18 +49,16 @@ class StaticQuestProviderTestCase: XCTestCase {
     
     // MARK: isQuestActive(_:)
     
-    func testIsQuestActive_shouldInitiallyReturnFalseForAllQuests() {
-        questProvider.quests.forEach { quest in
-            XCTAssertFalse(questProvider.isQuestActive(quest))
-        }
+    func testIsQuestActive_shouldInitiallyReturnFalse() {
+        let firstQuest = Quest.makeQuest()
+        setupQuestProvider(quests: [firstQuest])
+        
+        XCTAssertFalse(questProvider.isQuestActive(firstQuest))
     }
     
     func testIsQuestActive_whenTheQuestIdentifierIsPartOfTheUserDefaults_shouldReturnTrue() {
-        /// Just use the first quest as an example.
-        guard let firstQuest = questProvider.quests.first else {
-            XCTFail()
-            return
-        }
+        let firstQuest = Quest.makeQuest()
+        setupQuestProvider(quests: [firstQuest])
         
         /// Store the identifier in the `UserDefaults`.
         userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
@@ -71,11 +69,8 @@ class StaticQuestProviderTestCase: XCTestCase {
     /// This method makes sure that the values are persisted in the `UserDefaults`, and that when a second `StaticQuestProvider` is initialized
     /// with the same `UserDefaults` and the same `activeQuestIdentifierUserDefaultsKey`, a `Quest` is still considered "active".
     func testIsQuestActive_whenUsingTheSameUserDefaultsAndTheSameUserDefaultsKey_shouldStillReturnTrue() {
-        /// Just use the first quest as an example.
-        guard let firstQuest = questProvider.quests.first else {
-            XCTFail()
-            return
-        }
+        let firstQuest = Quest.makeQuest()
+        setupQuestProvider(quests: [firstQuest])
         
         /// Store the identifier in the `UserDefaults`.
         userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
@@ -89,11 +84,8 @@ class StaticQuestProviderTestCase: XCTestCase {
     // MARK: activateQuest(_:)
     
     func testActiveQuest_shouldStoreQuestIdentifierInUserDefaults() {
-        /// Just use the first quest as an example.
-        guard let firstQuest = questProvider.quests.first else {
-            XCTFail()
-            return
-        }
+        let firstQuest = Quest.makeQuest()
+        setupQuestProvider(quests: [firstQuest])
         
         questProvider.activateQuest(firstQuest)
         
@@ -108,11 +100,8 @@ class StaticQuestProviderTestCase: XCTestCase {
     }
     
     func testActiveQuest_shouldStoreQuestIdentifierInUserDefaultsOnlyOnce() {
-        /// Just use the first quest as an example.
-        guard let firstQuest = questProvider.quests.first else {
-            XCTFail()
-            return
-        }
+        let firstQuest = Quest.makeQuest()
+        setupQuestProvider(quests: [firstQuest])
         
         for _ in 1...10 {
             questProvider.activateQuest(firstQuest)
@@ -129,11 +118,8 @@ class StaticQuestProviderTestCase: XCTestCase {
     }
     
     func testActivateQuest_whenQuestWasNotActiveBefore_shouldPostNotification() {
-        /// Just use the first quest as an example.
-        guard let firstQuest = questProvider.quests.first else {
-            XCTFail()
-            return
-        }
+        let firstQuest = Quest.makeQuest()
+        setupQuestProvider(quests: [firstQuest])
         
         _ = expectation(forNotification: .QuestManagerDidUpdateActiveQuests,
                         object: questProvider,
@@ -145,11 +131,8 @@ class StaticQuestProviderTestCase: XCTestCase {
     }
     
     func testActivateQuest_whenQuestWasActiveBefore_shouldNotPostNotification() {
-        /// Just use the first quest as an example.
-        guard let firstQuest = questProvider.quests.first else {
-            XCTFail()
-            return
-        }
+        let firstQuest = Quest.makeQuest()
+        setupQuestProvider(quests: [firstQuest])
         
         /// Act as if the quest was active.
         userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
@@ -167,11 +150,8 @@ class StaticQuestProviderTestCase: XCTestCase {
     // MARK: deactivateQuest(_:)
     
     func testDeactiveQuest_shouldRemoveTheQuestIdentifierFromUserDefaults() {
-        /// Just use the first quest as an example.
-        guard let firstQuest = questProvider.quests.first else {
-            XCTFail()
-            return
-        }
+        let firstQuest = Quest.makeQuest()
+        setupQuestProvider(quests: [firstQuest])
         
         userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
         
@@ -188,11 +168,8 @@ class StaticQuestProviderTestCase: XCTestCase {
     }
     
     func testDeactivateQuest_whenQuestWasActiveBefore_shouldPostNotification() {
-        /// Just use the first quest as an example.
-        guard let firstQuest = questProvider.quests.first else {
-            XCTFail()
-            return
-        }
+        let firstQuest = Quest.makeQuest()
+        setupQuestProvider(quests: [firstQuest])
         
         /// Act as if the quest was active.
         userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
@@ -207,11 +184,8 @@ class StaticQuestProviderTestCase: XCTestCase {
     }
     
     func testDeactivateQuest_whenQuestWasNotActiveBefore_shouldNotPostNotification() {
-        /// Just use the first quest as an example.
-        guard let firstQuest = questProvider.quests.first else {
-            XCTFail()
-            return
-        }
+        let firstQuest = Quest.makeQuest()
+        setupQuestProvider(quests: [firstQuest])
         
         let notificationExpectation = expectation(forNotification: .QuestManagerDidUpdateActiveQuests,
                                                   object: questProvider,

--- a/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
@@ -34,5 +34,44 @@ class StaticQuestProviderTestCase: XCTestCase {
         
         super.tearDown()
     }
+    
+    // MARK: isQuestActive(_:)
+    
+    func testIsQuestActive_shouldInitiallyReturnFalseForAllQuests() {
+        questProvider.quests.forEach { quest in
+            XCTAssertFalse(questProvider.isQuestActive(quest))
+        }
+    }
+    
+    func testIsQuestActive_whenTheQuestIdentifierIsPartOfTheUserDefaults_shouldReturnTrue() {
+        /// Just use the first quest as an example.
+        guard let firstQuest = questProvider.quests.first else {
+            XCTFail()
+            return
+        }
+        
+        /// Store the identifier in the `UserDefaults`.
+        userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
+        
+        XCTAssertTrue(questProvider.isQuestActive(firstQuest))
+    }
+    
+    /// This method makes sure that the values are persisted in the `UserDefaults`, and that when a second `StaticQuestProvider` is initialized
+    /// with the same `UserDefaults` and the same `activeQuestIdentifierUserDefaultsKey`, a `Quest` is still considered "active".
+    func testIsQuestActive_whenUsingTheSameUserDefaultsAndTheSameUserDefaultsKey_shouldStillReturnTrue() {
+        /// Just use the first quest as an example.
+        guard let firstQuest = questProvider.quests.first else {
+            XCTFail()
+            return
+        }
+        
+        /// Store the identifier in the `UserDefaults`.
+        userDefaults.set([firstQuest.identifier], forKey: activeQuestIdentifierUserDefaultsKey)
+        
+        /// Create a second `StaticQuestProvider` with the same values.
+        let secondQuestProvider = StaticQuestProvider(userDefaults: userDefaults,
+                                                      activeQuestIdentifierUserDefaultsKey: activeQuestIdentifierUserDefaultsKey)
+        XCTAssertTrue(secondQuestProvider.isQuestActive(firstQuest))
+    }
 
 }

--- a/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
@@ -1,0 +1,29 @@
+//
+//  StaticQuestProviderTestCase.swift
+//  GoMapTests
+//
+//  Created by Wolfgang Timme on 1/4/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+import XCTest
+
+@testable import Go_Map__
+
+class StaticQuestProviderTestCase: XCTestCase {
+    
+    var questProvider: QuestProviding!
+
+    override func setUp() {
+        super.setUp()
+        
+        questProvider = StaticQuestProvider()
+    }
+
+    override func tearDown() {
+        questProvider = nil
+        
+        super.tearDown()
+    }
+
+}

--- a/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/StaticQuestProviderTestCase.swift
@@ -17,6 +17,7 @@ class StaticQuestProviderTestCase: XCTestCase {
     var userDefaults: UserDefaults!
     let userDefaultsSuiteName = "TestDefaults"
     let activeQuestIdentifierUserDefaultsKey = "identifiers"
+    var notificationCenter: NotificationCenter!
 
     override func setUp() {
         super.setUp()
@@ -24,13 +25,17 @@ class StaticQuestProviderTestCase: XCTestCase {
         UserDefaults().removePersistentDomain(forName: userDefaultsSuiteName)
         userDefaults = UserDefaults(suiteName: userDefaultsSuiteName)
         
+        notificationCenter = NotificationCenter()
+        
         questProvider = StaticQuestProvider(userDefaults: userDefaults,
-                                            activeQuestIdentifierUserDefaultsKey: activeQuestIdentifierUserDefaultsKey)
+                                            activeQuestIdentifierUserDefaultsKey: activeQuestIdentifierUserDefaultsKey,
+                                            notificationCenter: notificationCenter)
     }
 
     override func tearDown() {
         questProvider = nil
         userDefaults = nil
+        notificationCenter = nil
         
         super.tearDown()
     }

--- a/src/iOS/GoMapUITests/Info.plist
+++ b/src/iOS/GoMapUITests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 </dict>
 </plist>

--- a/src/iOS/GoMapUITests/QuestListUITestCase.swift
+++ b/src/iOS/GoMapUITests/QuestListUITestCase.swift
@@ -1,0 +1,27 @@
+//
+//  QuestListUITestCase.swift
+//  GoMapUITests
+//
+//  Created by Wolfgang Timme on 1/4/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+import XCTest
+
+class QuestListUITestCase: XCTestCase {
+
+    var app: XCUIApplication!
+    
+    override func setUp() {
+        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+        app = XCUIApplication()
+        setupSnapshot(app)
+        app.launch()
+    }
+    
+    override func tearDown() {
+        app.terminate()
+        app = nil
+    }
+
+}

--- a/src/iOS/GoMapUITests/QuestListUITestCase.swift
+++ b/src/iOS/GoMapUITests/QuestListUITestCase.swift
@@ -23,5 +23,22 @@ class QuestListUITestCase: XCTestCase {
         app.terminate()
         app = nil
     }
+    
+    func testTapOnQuestsMenuItemInDisplayOptionsShouldShowQuestListViewController() {
+        goToQuestListViewController()
+    }
+    
+    // MARK: Helper methods
+    
+    private func goToQuestListViewController() {
+        let button = app.buttons["display_options_button"]
+        button.press(forDuration: 1.0)
+        
+        waitForViewController("Display")
+        
+        app.cells["quests"].tap()
+        
+        waitForViewController("Quests")
+    }
 
 }

--- a/src/iOS/GoMapUITests/QuestListUITestCase.swift
+++ b/src/iOS/GoMapUITests/QuestListUITestCase.swift
@@ -26,6 +26,8 @@ class QuestListUITestCase: XCTestCase {
     
     func testTapOnQuestsMenuItemInDisplayOptionsShouldShowQuestListViewController() {
         goToQuestListViewController()
+        
+        snapshot("02QuestList")
     }
     
     func testQuestList_shouldNotBeEmpty() {

--- a/src/iOS/GoMapUITests/QuestListUITestCase.swift
+++ b/src/iOS/GoMapUITests/QuestListUITestCase.swift
@@ -28,6 +28,12 @@ class QuestListUITestCase: XCTestCase {
         goToQuestListViewController()
     }
     
+    func testQuestList_shouldNotBeEmpty() {
+        goToQuestListViewController()
+        
+        XCTAssert(app.tables.children(matching: .cell).count > 0)
+    }
+    
     // MARK: Helper methods
     
     private func goToQuestListViewController() {

--- a/src/iOS/Overpass/MapViewQuestAnnotationManager.swift
+++ b/src/iOS/Overpass/MapViewQuestAnnotationManager.swift
@@ -17,6 +17,7 @@ import Foundation
     // MARK: Private properties
     
     private let questManager: QuestManaging
+    private let questProvider: QuestProviding
     private let queryParser: OverpassQueryParsing
     
     private var lastParsedQuery: String?
@@ -24,18 +25,20 @@ import Foundation
     
     // MARK: Initializer
     
-    init(questManager: QuestManaging, queryParser: OverpassQueryParsing) {
+    init(questManager: QuestManaging, questProvider: QuestProviding, queryParser: OverpassQueryParsing) {
         self.questManager = questManager
+        self.questProvider = questProvider
         self.queryParser = queryParser
     }
     
     convenience override init() {
         let questManager = QuestManager()
+        let questProvider = StaticQuestProvider()
         
         let parser = OverpassQueryParser()
         assert(parser != nil, "Unable to create the query parser.")
         
-        self.init(questManager: questManager, queryParser: parser!)
+        self.init(questManager: questManager, questProvider: questProvider, queryParser: parser!)
     }
     
     // MARK: MapViewQuestAnnotationManaging

--- a/src/iOS/Overpass/MapViewQuestAnnotationManager.swift
+++ b/src/iOS/Overpass/MapViewQuestAnnotationManager.swift
@@ -25,7 +25,9 @@ import Foundation
     
     // MARK: Initializer
     
-    init(questManager: QuestManaging, questProvider: QuestProviding, queryParser: OverpassQueryParsing) {
+    init(questManager: QuestManaging,
+         questProvider: QuestProviding,
+         queryParser: OverpassQueryParsing) {
         self.questManager = questManager
         self.questProvider = questProvider
         self.queryParser = queryParser

--- a/src/iOS/Overpass/MapViewQuestAnnotationManager.swift
+++ b/src/iOS/Overpass/MapViewQuestAnnotationManager.swift
@@ -19,6 +19,7 @@ import Foundation
     private let questManager: QuestManaging
     private let questProvider: QuestProviding
     private let queryParser: OverpassQueryParsing
+    private let notificationCenter: NotificationCenter
     
     private var lastParsedQuery: String?
     private var lastMatcher: BaseObjectMatching?
@@ -27,10 +28,12 @@ import Foundation
     
     init(questManager: QuestManaging,
          questProvider: QuestProviding,
-         queryParser: OverpassQueryParsing) {
+         queryParser: OverpassQueryParsing,
+         notificationCenter: NotificationCenter = .default) {
         self.questManager = questManager
         self.questProvider = questProvider
         self.queryParser = queryParser
+        self.notificationCenter = notificationCenter
     }
     
     convenience override init() {

--- a/src/iOS/Overpass/MapViewQuestAnnotationManager.swift
+++ b/src/iOS/Overpass/MapViewQuestAnnotationManager.swift
@@ -49,14 +49,25 @@ import Foundation
     // MARK: MapViewQuestAnnotationManaging
     
     func shouldShowQuestAnnotation(for baseObject: OsmBaseObject) -> Bool {
-        guard let activeQuery = questManager.activeQuestQuery else {
-            // Without an active query, there's no need to show an annotation.
+        guard let overpassTurboWizardQueryMatcher = matcherFromOverpassTurboWizardQuery() else {
+            /// Without a matcher, there's no need to show a quest annotation.
             return false
+        }
+        
+        return overpassTurboWizardQueryMatcher.matches(baseObject)
+    }
+    
+    /// Uses the Overpass Turbo Wizard Query that the user entered and attempts to create a matcher from it.
+    private func matcherFromOverpassTurboWizardQuery() -> BaseObjectMatching? {
+        guard let activeQuery = questManager.activeQuestQuery else {
+            /// Without an active query, there's no matcher.
+            return nil
         }
         
         guard activeQuery != lastParsedQuery else {
             // We've already parsed this query before, and there's no need to do it again.
-            return lastMatcher?.matches(baseObject) ?? false
+            /// Use the existing matcher.
+            return lastMatcher
         }
         
         // Remember the query that was parsed last.
@@ -68,13 +79,13 @@ import Foundation
         else {
             lastMatcher = nil
             
-            return false
+            return nil
         }
         
         // Remember the parsed matcher.
         lastMatcher = matcher
         
-        return matcher.matches(baseObject)
+        return matcher
     }
 
 }

--- a/src/iOS/Overpass/Quest+staticQuests.swift
+++ b/src/iOS/Overpass/Quest+staticQuests.swift
@@ -29,4 +29,14 @@ extension Quest {
                      overpassWizardQuery: query)
     }
     
+    static func makeBenchBackrestQuest() -> Quest {
+        let identifier = "bench_backrest"
+        let question = "Does this bench have a backrest?"
+        let query = "(type:node) and amenity=bench and backrest!=*"
+        
+        return Quest(identifier: identifier,
+                     question: question,
+                     overpassWizardQuery: query)
+    }
+    
 }

--- a/src/iOS/Overpass/Quest+staticQuests.swift
+++ b/src/iOS/Overpass/Quest+staticQuests.swift
@@ -9,4 +9,14 @@
 /// This extension contains `Quest`s that are compiled into the app.
 extension Quest {
     
+    static func makeAccessibleToiletsQuest() -> Quest {
+        let identifier = "accessible_toilets"
+        let question = "Are these toilets wheelchair accessible?"
+        let query = "(type:node or type:way) and amenity=toilets and access !~ \"private|customers\" and wheelchair!=*"
+        
+        return Quest(identifier: identifier,
+                     question: question,
+                     overpassWizardQuery: query)
+    }
+    
 }

--- a/src/iOS/Overpass/Quest+staticQuests.swift
+++ b/src/iOS/Overpass/Quest+staticQuests.swift
@@ -39,4 +39,14 @@ extension Quest {
                      overpassWizardQuery: query)
     }
     
+    static func makePlaygroundAccessQuest() -> Quest {
+        let identifier = "playground_access"
+        let question = "Is this playground generally accessible?"
+        let query = "leisure=playground and (access!=* or access=unknown)"
+        
+        return Quest(identifier: identifier,
+        question: question,
+        overpassWizardQuery: query)
+    }
+    
 }

--- a/src/iOS/Overpass/Quest+staticQuests.swift
+++ b/src/iOS/Overpass/Quest+staticQuests.swift
@@ -49,4 +49,14 @@ extension Quest {
         overpassWizardQuery: query)
     }
     
+    static func makeToiletQuest() -> Quest {
+        let identifier = "toilet"
+        let question = "Does this place have a toilet?"
+        let query = "(type:node or type:way) and ( (shop ~= \"mall|department_store\" and name = *) or (highway~\"services|rest_area\") ) and toilets != *"
+        
+        return Quest(identifier: identifier,
+                     question: question,
+                     overpassWizardQuery: query)
+    }
+    
 }

--- a/src/iOS/Overpass/Quest+staticQuests.swift
+++ b/src/iOS/Overpass/Quest+staticQuests.swift
@@ -1,0 +1,12 @@
+//
+//  Quest+staticQuests.swift
+//  Go Map!!
+//
+//  Created by Wolfgang Timme on 1/5/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+/// This extension contains `Quest`s that are compiled into the app.
+extension Quest {
+    
+}

--- a/src/iOS/Overpass/Quest+staticQuests.swift
+++ b/src/iOS/Overpass/Quest+staticQuests.swift
@@ -19,4 +19,14 @@ extension Quest {
                      overpassWizardQuery: query)
     }
     
+    static func makeParkingFeeQuest() -> Quest {
+        let identifier = "parking_fee"
+        let question = "Does it cost a fee to park here? "
+        let query = "(type:node or type:way) and amenity=parking and fee!=* and access~\"yes|customers|public\""
+        
+        return Quest(identifier: identifier,
+                     question: question,
+                     overpassWizardQuery: query)
+    }
+    
 }

--- a/src/iOS/Overpass/Quest.swift
+++ b/src/iOS/Overpass/Quest.swift
@@ -10,6 +10,10 @@
 ///
 /// The name stems from the Android app [StreetComplete](https://wiki.openstreetmap.org/wiki/StreetComplete/Quests).
 struct Quest {
+    /// A unique string that identifies this `Quest`.
+    /// This is used to refer to it when saving its `isActive` state.
+    let identifier: String
+    
     /// The question that the user is asked when encountering a map item for this quest.
     let question: String
     

--- a/src/iOS/Overpass/Quest.swift
+++ b/src/iOS/Overpass/Quest.swift
@@ -1,0 +1,20 @@
+//
+//  Quest.swift
+//  Go Map!!
+//
+//  Created by Wolfgang Timme on 1/4/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+/// Represents a task/challenge that the user should fulfil.
+///
+/// The name stems from the Android app [StreetComplete](https://wiki.openstreetmap.org/wiki/StreetComplete/Quests).
+struct Quest {
+    /// The question that the user is asked when encountering a map item for this quest.
+    let question: String
+    
+    /// A query that is used to filter items that match this quest.
+    ///
+    /// Uses the [Overpass Turbo Wizard](https://wiki.openstreetmap.org/wiki/Overpass_turbo/Wizard) format.
+    let overpassWizardQuery: String
+}

--- a/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
+++ b/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
@@ -68,4 +68,8 @@ class QuestListTableViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return UITableView.automaticDimension
     }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
 }

--- a/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
+++ b/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
@@ -1,0 +1,29 @@
+//
+//  QuestListTableViewController.swift
+//  Go Map!!
+//
+//  Created by Wolfgang Timme on 1/4/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+import UIKit
+
+class QuestListTableViewController: UITableViewController {
+        
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = NSLocalizedString("Quests",
+                                  comment: "Title of the quest list")
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 0
+    }
+}

--- a/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
+++ b/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
@@ -38,6 +38,9 @@ class QuestListTableViewController: UITableViewController {
             cell = dequeuedCell
         } else {
             cell = UITableViewCell(style: .subtitle, reuseIdentifier: itemCellReuseIdentifier)
+            
+            cell.textLabel?.numberOfLines = 0
+            cell.detailTextLabel?.numberOfLines = 0
         }
         
         let item = viewModel.item(at: indexPath.row)
@@ -46,5 +49,13 @@ class QuestListTableViewController: UITableViewController {
         cell.detailTextLabel?.text = item?.subtitle
 
         return cell
+    }
+    
+    override func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 42
+    }
+    
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
     }
 }

--- a/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
+++ b/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
@@ -9,6 +9,10 @@
 import UIKit
 
 class QuestListTableViewController: UITableViewController {
+    
+    // MARK: Private properties
+    
+    private let viewModel = QuestListViewModel()
         
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
+++ b/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
@@ -62,6 +62,8 @@ class QuestListTableViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        viewModel.selectItem(at: indexPath.row)
+        
         tableView.deselectRow(at: indexPath, animated: true)
     }
     

--- a/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
+++ b/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
@@ -43,10 +43,13 @@ class QuestListTableViewController: UITableViewController {
             cell.detailTextLabel?.numberOfLines = 0
         }
         
-        let item = viewModel.item(at: indexPath.row)
+        guard let item = viewModel.item(at: indexPath.row) else {
+            /// Without an `Item`, we cannot configure the cell.
+            return cell
+        }
         
-        cell.textLabel?.text = item?.title
-        cell.detailTextLabel?.text = item?.subtitle
+        cell.textLabel?.text = item.title
+        cell.detailTextLabel?.text = item.subtitle
 
         return cell
     }

--- a/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
+++ b/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
@@ -48,15 +48,7 @@ class QuestListTableViewController: UITableViewController {
             return cell
         }
         
-        cell.textLabel?.text = item.title
-        cell.detailTextLabel?.text = item.subtitle
-        
-        switch item.accessory {
-        case .checkmark:
-            cell.accessoryType = .checkmark
-        case .none:
-            cell.accessoryType = .none
-        }
+        configure(cell: cell, with: item)
 
         return cell
     }
@@ -71,5 +63,17 @@ class QuestListTableViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+    }
+    
+    private func configure(cell: UITableViewCell, with item: QuestListViewModel.Item) {
+        cell.textLabel?.text = item.title
+        cell.detailTextLabel?.text = item.subtitle
+        
+        switch item.accessory {
+        case .checkmark:
+            cell.accessoryType = .checkmark
+        case .none:
+            cell.accessoryType = .none
+        }
     }
 }

--- a/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
+++ b/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
@@ -50,6 +50,13 @@ class QuestListTableViewController: UITableViewController {
         
         cell.textLabel?.text = item.title
         cell.detailTextLabel?.text = item.subtitle
+        
+        switch item.accessory {
+        case .checkmark:
+            cell.accessoryType = .checkmark
+        case .none:
+            cell.accessoryType = .none
+        }
 
         return cell
     }

--- a/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
+++ b/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
@@ -13,6 +13,7 @@ class QuestListTableViewController: UITableViewController {
     // MARK: Private properties
     
     private let viewModel = QuestListViewModel()
+    private let itemCellReuseIdentifier = "ItemCell"
         
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -28,6 +29,22 @@ class QuestListTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 0
+        return viewModel.numberOfItems()
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell: UITableViewCell
+        if let dequeuedCell = tableView.dequeueReusableCell(withIdentifier: itemCellReuseIdentifier) {
+            cell = dequeuedCell
+        } else {
+            cell = UITableViewCell(style: .subtitle, reuseIdentifier: itemCellReuseIdentifier)
+        }
+        
+        let item = viewModel.item(at: indexPath.row)
+        
+        cell.textLabel?.text = item?.title
+        cell.detailTextLabel?.text = item?.subtitle
+
+        return cell
     }
 }

--- a/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
+++ b/src/iOS/Overpass/QuestList/QuestListTableViewController.swift
@@ -17,6 +17,8 @@ class QuestListTableViewController: UITableViewController {
         
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        viewModel.delegate = self
 
         title = NSLocalizedString("Quests",
                                   comment: "Title of the quest list")
@@ -77,5 +79,21 @@ class QuestListTableViewController: UITableViewController {
         case .none:
             cell.accessoryType = .none
         }
+    }
+}
+
+extension QuestListTableViewController: QuestListViewModelDelegate {
+    func reloadItem(at index: Int) {
+        let indexPath = IndexPath(row: index, section: 0)
+        
+        guard
+            let cell = tableView.cellForRow(at: indexPath),
+            let item = viewModel.item(at: index)
+        else {
+            /// Without a cell, there's nothing we can reload.
+            return
+        }
+        
+        configure(cell: cell, with: item)
     }
 }

--- a/src/iOS/Overpass/QuestList/QuestListTableViewController.xib
+++ b/src/iOS/Overpass/QuestList/QuestListTableViewController.xib
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="QuestListTableViewController" customModule="Go_Map__" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" bouncesZoom="NO" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="vLr-E1-eTs"/>
+            <connections>
+                <outlet property="dataSource" destination="-1" id="Tng-2m-Rnh"/>
+                <outlet property="delegate" destination="-1" id="9aC-8N-iBw"/>
+            </connections>
+            <point key="canvasLocation" x="139" y="90"/>
+        </tableView>
+    </objects>
+</document>

--- a/src/iOS/Overpass/QuestList/QuestListViewModel.swift
+++ b/src/iOS/Overpass/QuestList/QuestListViewModel.swift
@@ -43,7 +43,9 @@ class QuestListViewModel {
             return nil
         }
         
-        return Item(title: allQuests[index].question,
-                    subtitle: allQuests[index].overpassWizardQuery)
+        let quest = allQuests[index]
+        
+        return Item(title: quest.question,
+                    subtitle: quest.overpassWizardQuery)
     }
 }

--- a/src/iOS/Overpass/QuestList/QuestListViewModel.swift
+++ b/src/iOS/Overpass/QuestList/QuestListViewModel.swift
@@ -11,8 +11,13 @@ class QuestListViewModel {
     
     /// An item in the list.
     struct Item {
+        enum Accessory {
+            case none, checkmark
+        }
+        
         let title: String
         let subtitle: String
+        let accessory: Accessory
     }
     
     // MARK: Private properties
@@ -48,6 +53,7 @@ class QuestListViewModel {
         _ = questProvider.isQuestActive(quest)
         
         return Item(title: quest.question,
-                    subtitle: quest.overpassWizardQuery)
+                    subtitle: quest.overpassWizardQuery,
+                    accessory: .none)
     }
 }

--- a/src/iOS/Overpass/QuestList/QuestListViewModel.swift
+++ b/src/iOS/Overpass/QuestList/QuestListViewModel.swift
@@ -45,6 +45,8 @@ class QuestListViewModel {
         
         let quest = allQuests[index]
         
+        _ = questProvider.isQuestActive(quest)
+        
         return Item(title: quest.question,
                     subtitle: quest.overpassWizardQuery)
     }

--- a/src/iOS/Overpass/QuestList/QuestListViewModel.swift
+++ b/src/iOS/Overpass/QuestList/QuestListViewModel.swift
@@ -1,0 +1,11 @@
+//
+//  QuestListViewModel.swift
+//  Go Map!!
+//
+//  Created by Wolfgang Timme on 1/4/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+class QuestListViewModel {
+
+}

--- a/src/iOS/Overpass/QuestList/QuestListViewModel.swift
+++ b/src/iOS/Overpass/QuestList/QuestListViewModel.swift
@@ -17,4 +17,11 @@ class QuestListViewModel {
     init(questProvider: QuestProviding = StaticQuestProvider()) {
         self.questProvider = questProvider
     }
+    
+    // MARK: Public methods
+    
+    /// The number of items visible in the list
+    func numberOfItems() -> Int {
+        return questProvider.quests.count
+    }
 }

--- a/src/iOS/Overpass/QuestList/QuestListViewModel.swift
+++ b/src/iOS/Overpass/QuestList/QuestListViewModel.swift
@@ -7,5 +7,14 @@
 //
 
 class QuestListViewModel {
-
+    // MARK: Private properties
+    
+    /// An object that provides the `Quest` instances that are displayed in the list
+    private let questProvider: QuestProviding
+    
+    // MARK: Initializer
+    
+    init(questProvider: QuestProviding = StaticQuestProvider()) {
+        self.questProvider = questProvider
+    }
 }

--- a/src/iOS/Overpass/QuestList/QuestListViewModel.swift
+++ b/src/iOS/Overpass/QuestList/QuestListViewModel.swift
@@ -26,6 +26,10 @@ class QuestListViewModel {
         let accessory: Accessory
     }
     
+    // MARK: Public properties
+    
+    weak var delegate: QuestListViewModelDelegate?
+    
     // MARK: Private properties
     
     /// An object that provides the `Quest` instances that are displayed in the list
@@ -78,5 +82,7 @@ class QuestListViewModel {
         } else {
             questProvider.activateQuest(quest)
         }
+        
+        delegate?.reloadItem(at: index)
     }
 }

--- a/src/iOS/Overpass/QuestList/QuestListViewModel.swift
+++ b/src/iOS/Overpass/QuestList/QuestListViewModel.swift
@@ -50,10 +50,10 @@ class QuestListViewModel {
         
         let quest = allQuests[index]
         
-        _ = questProvider.isQuestActive(quest)
+        let accessory: Item.Accessory = questProvider.isQuestActive(quest) ? .checkmark : .none
         
         return Item(title: quest.question,
                     subtitle: quest.overpassWizardQuery,
-                    accessory: .none)
+                    accessory: accessory)
     }
 }

--- a/src/iOS/Overpass/QuestList/QuestListViewModel.swift
+++ b/src/iOS/Overpass/QuestList/QuestListViewModel.swift
@@ -6,6 +6,12 @@
 //  Copyright © 2020 Bryce. All rights reserved.
 //
 
+protocol QuestListViewModelDelegate: class {
+    /// Asks the delegate to reload the item at the given index.
+    /// - Parameter index: The index at which to reload the item.
+    func reloadItem(at index: Int)
+}
+
 class QuestListViewModel {
     // MARK: Types
     

--- a/src/iOS/Overpass/QuestList/QuestListViewModel.swift
+++ b/src/iOS/Overpass/QuestList/QuestListViewModel.swift
@@ -32,4 +32,18 @@ class QuestListViewModel {
     func numberOfItems() -> Int {
         return questProvider.quests.count
     }
+    
+    /// Determines the `Item` to display at the given `index`.
+    /// - Parameter index: The index of the item.
+    func item(at index: Int) -> Item? {
+        let allQuests = questProvider.quests
+        
+        guard allQuests.indices.contains(index) else {
+            /// The index is out-of-range.
+            return nil
+        }
+        
+        return Item(title: allQuests[index].question,
+                    subtitle: allQuests[index].overpassWizardQuery)
+    }
 }

--- a/src/iOS/Overpass/QuestList/QuestListViewModel.swift
+++ b/src/iOS/Overpass/QuestList/QuestListViewModel.swift
@@ -7,6 +7,14 @@
 //
 
 class QuestListViewModel {
+    // MARK: Types
+    
+    /// An item in the list.
+    struct Item {
+        let title: String
+        let subtitle: String
+    }
+    
     // MARK: Private properties
     
     /// An object that provides the `Quest` instances that are displayed in the list

--- a/src/iOS/Overpass/QuestList/QuestListViewModel.swift
+++ b/src/iOS/Overpass/QuestList/QuestListViewModel.swift
@@ -56,4 +56,21 @@ class QuestListViewModel {
                     subtitle: quest.overpassWizardQuery,
                     accessory: accessory)
     }
+    
+    func selectItem(at index: Int) {
+        let allQuests = questProvider.quests
+        
+        guard allQuests.indices.contains(index) else {
+            /// The index is out-of-range.
+            return
+        }
+        
+        let quest = allQuests[index]
+        
+        if questProvider.isQuestActive(quest) {
+            questProvider.deactivateQuest(quest)
+        } else {
+            questProvider.activateQuest(quest)
+        }
+    }
 }

--- a/src/iOS/Overpass/QuestList/QuestProviding.swift
+++ b/src/iOS/Overpass/QuestList/QuestProviding.swift
@@ -17,4 +17,8 @@ protocol QuestProviding {
     /// Activates the given quest.
     /// - Parameter quest: The quest to activate.
     func activateQuest(_ quest: Quest)
+    
+    /// Deactivates the given quest.
+    /// - Parameter quest: The quest to deactivate.
+    func deactivateQuest(_ quest: Quest)
 }

--- a/src/iOS/Overpass/QuestList/QuestProviding.swift
+++ b/src/iOS/Overpass/QuestList/QuestProviding.swift
@@ -9,4 +9,8 @@
 /// Protocol for an object that provides `Quest` instances
 protocol QuestProviding {
     var quests: [Quest] { get }
+    
+    /// Determines whether the given `Quest` is active.
+    /// - Parameter quest: The quest to check.
+    func isQuestActive(_ quest: Quest) -> Bool
 }

--- a/src/iOS/Overpass/QuestList/QuestProviding.swift
+++ b/src/iOS/Overpass/QuestList/QuestProviding.swift
@@ -1,0 +1,12 @@
+//
+//  QuestProviding.swift
+//  Go Map!!
+//
+//  Created by Wolfgang Timme on 1/4/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+/// Protocol for an object that provides `Quest` instances
+protocol QuestProviding {
+    var quests: [Quest] { get }
+}

--- a/src/iOS/Overpass/QuestList/QuestProviding.swift
+++ b/src/iOS/Overpass/QuestList/QuestProviding.swift
@@ -10,6 +10,9 @@
 protocol QuestProviding {
     var quests: [Quest] { get }
     
+    /// The quests that are currently active.
+    var activeQuests: [Quest] { get }
+    
     /// Determines whether the given `Quest` is active.
     /// - Parameter quest: The quest to check.
     func isQuestActive(_ quest: Quest) -> Bool

--- a/src/iOS/Overpass/QuestList/QuestProviding.swift
+++ b/src/iOS/Overpass/QuestList/QuestProviding.swift
@@ -13,4 +13,8 @@ protocol QuestProviding {
     /// Determines whether the given `Quest` is active.
     /// - Parameter quest: The quest to check.
     func isQuestActive(_ quest: Quest) -> Bool
+    
+    /// Activates the given quest.
+    /// - Parameter quest: The quest to activate.
+    func activateQuest(_ quest: Quest)
 }

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -37,6 +37,12 @@ class StaticQuestProvider {
 
 extension StaticQuestProvider: QuestProviding {
     
+    var activeQuests: [Quest] {
+        let identifiersOfActiveQuests = activeQuestIdentifiersFromUserDefaults()
+        
+        return quests.filter { identifiersOfActiveQuests.contains($0.identifier) }
+    }
+    
     func isQuestActive(_ quest: Quest) -> Bool {
         return activeQuestIdentifiersFromUserDefaults().contains(quest.identifier)
     }

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -24,7 +24,8 @@ class StaticQuestProvider {
     
     // MARK: Initializer
     
-    init(quests: [Quest] = [Quest.makeAccessibleToiletsQuest(), Quest.makeParkingFeeQuest()],
+    init(quests: [Quest] = [Quest.makeAccessibleToiletsQuest(),
+                            Quest.makeParkingFeeQuest()],
          userDefaults: UserDefaults = .standard,
          activeQuestIdentifierUserDefaultsKey: String = "active_quest_identifiers",
          notificationCenter: NotificationCenter = .default) {

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -62,7 +62,7 @@ extension StaticQuestProvider: QuestProviding {
     func activateQuest(_ quest: Quest) {
         var identifiers = activeQuestIdentifiersFromUserDefaults()
         
-        guard !identifiers.contains(quest.identifier) else {
+        guard !isQuestActive(quest) else {
             /// The quest is already active; ignore the call.
             return
         }

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -55,6 +55,19 @@ extension StaticQuestProvider: QuestProviding {
         return activeQuestIdentifiersFromUserDefaults().contains(quest.identifier)
     }
     
+    func activateQuest(_ quest: Quest) {
+        var identifiers = activeQuestIdentifiersFromUserDefaults()
+        
+        guard !identifiers.contains(quest.identifier) else {
+            /// The quest is already active; ignore the call.
+            return
+        }
+        
+        identifiers.append(quest.identifier)
+        
+        userDefaults.set(identifiers, forKey: activeQuestIdentifierUserDefaultsKey)
+    }
+    
     private func activeQuestIdentifiersFromUserDefaults() -> [String] {
         guard
             let activeQuestIdentifiers = userDefaults.object(forKey: activeQuestIdentifierUserDefaultsKey) as? [String]

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -78,6 +78,11 @@ extension StaticQuestProvider: QuestProviding {
     func deactivateQuest(_ quest: Quest) {
         var identifiers = activeQuestIdentifiersFromUserDefaults()
         
+        guard isQuestActive(quest) else {
+            /// The quest is not active; ignore the call.
+            return
+        }
+        
         identifiers.removeAll(where: { $0 == quest.identifier })
         
         userDefaults.set(identifiers, forKey: activeQuestIdentifierUserDefaultsKey)

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -27,7 +27,8 @@ class StaticQuestProvider {
     init(quests: [Quest] = [Quest.makeAccessibleToiletsQuest(),
                             Quest.makeParkingFeeQuest(),
                             Quest.makeBenchBackrestQuest(),
-                            Quest.makePlaygroundAccessQuest()],
+                            Quest.makePlaygroundAccessQuest(),
+                            Quest.makeToiletQuest()],
          userDefaults: UserDefaults = .standard,
          activeQuestIdentifierUserDefaultsKey: String = "active_quest_identifiers",
          notificationCenter: NotificationCenter = .default) {

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -17,10 +17,21 @@ class StaticQuestProvider {
                      question: question,
                      overpassWizardQuery: query)
     }
+    
+    private var parkingFeeQuest: Quest {
+        let identifier = "parking_fee"
+        let question = "Does it cost a fee to park here? "
+        let query = "(type:node or type:way) and amenity=parking and fee!=* and access~\"yes|customers|public\""
+        
+        return Quest(identifier: identifier,
+                     question: question,
+                     overpassWizardQuery: query)
+    }
 }
 
 extension StaticQuestProvider: QuestProviding {
     var quests: [Quest] {
-        [accessibleToiletsQuest]
+        [accessibleToiletsQuest,
+         parkingFeeQuest]
     }
 }

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -70,6 +70,9 @@ extension StaticQuestProvider: QuestProviding {
         identifiers.append(quest.identifier)
         
         userDefaults.set(identifiers, forKey: activeQuestIdentifierUserDefaultsKey)
+        
+        /// Post a notification.
+        notificationCenter.post(name: .QuestManagerDidUpdateActiveQuests, object: self)
     }
     
     func deactivateQuest(_ quest: Quest) {

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -18,16 +18,6 @@ class StaticQuestProvider {
     
     private let notificationCenter: NotificationCenter
     
-    private var accessibleToiletsQuest: Quest {
-        let identifier = "accessible_toilets"
-        let question = "Are these toilets wheelchair accessible?"
-        let query = "(type:node or type:way) and amenity=toilets and access !~ \"private|customers\" and wheelchair!=*"
-        
-        return Quest(identifier: identifier,
-                     question: question,
-                     overpassWizardQuery: query)
-    }
-    
     private var parkingFeeQuest: Quest {
         let identifier = "parking_fee"
         let question = "Does it cost a fee to park here? "
@@ -51,7 +41,7 @@ class StaticQuestProvider {
 
 extension StaticQuestProvider: QuestProviding {
     var quests: [Quest] {
-        [accessibleToiletsQuest,
+        [Quest.makeAccessibleToiletsQuest(),
          parkingFeeQuest]
     }
     

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -52,12 +52,16 @@ extension StaticQuestProvider: QuestProviding {
     }
     
     func isQuestActive(_ quest: Quest) -> Bool {
+        return activeQuestIdentifiersFromUserDefaults().contains(quest.identifier)
+    }
+    
+    private func activeQuestIdentifiersFromUserDefaults() -> [String] {
         guard
             let activeQuestIdentifiers = userDefaults.object(forKey: activeQuestIdentifierUserDefaultsKey) as? [String]
         else {
-            return false
+            return []
         }
         
-        return activeQuestIdentifiers.contains(quest.identifier)
+        return activeQuestIdentifiers
     }
 }

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -10,6 +10,9 @@
 class StaticQuestProvider {
     // MARK: Private properties
     
+    /// The `UserDefaults` instances for persisting the active quests.
+    private let userDefaults: UserDefaults
+    
     private var accessibleToiletsQuest: Quest {
         let identifier = "accessible_toilets"
         let question = "Are these toilets wheelchair accessible?"
@@ -28,6 +31,12 @@ class StaticQuestProvider {
         return Quest(identifier: identifier,
                      question: question,
                      overpassWizardQuery: query)
+    }
+    
+    // MARK: Initializer
+    
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
     }
 }
 

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -16,6 +16,8 @@ class StaticQuestProvider {
     /// Key for when storing the identifiers of the active quests in the `UserDefaults`.
     private let activeQuestIdentifierUserDefaultsKey: String
     
+    private let notificationCenter: NotificationCenter
+    
     private var accessibleToiletsQuest: Quest {
         let identifier = "accessible_toilets"
         let question = "Are these toilets wheelchair accessible?"
@@ -39,9 +41,11 @@ class StaticQuestProvider {
     // MARK: Initializer
     
     init(userDefaults: UserDefaults = .standard,
-         activeQuestIdentifierUserDefaultsKey: String = "active_quest_identifiers") {
+         activeQuestIdentifierUserDefaultsKey: String = "active_quest_identifiers",
+         notificationCenter: NotificationCenter = .default) {
         self.userDefaults = userDefaults
         self.activeQuestIdentifierUserDefaultsKey = activeQuestIdentifierUserDefaultsKey
+        self.notificationCenter = notificationCenter
     }
 }
 

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -25,7 +25,8 @@ class StaticQuestProvider {
     // MARK: Initializer
     
     init(quests: [Quest] = [Quest.makeAccessibleToiletsQuest(),
-                            Quest.makeParkingFeeQuest()],
+                            Quest.makeParkingFeeQuest(),
+                            Quest.makeBenchBackrestQuest()],
          userDefaults: UserDefaults = .standard,
          activeQuestIdentifierUserDefaultsKey: String = "active_quest_identifiers",
          notificationCenter: NotificationCenter = .default) {

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -68,6 +68,14 @@ extension StaticQuestProvider: QuestProviding {
         userDefaults.set(identifiers, forKey: activeQuestIdentifierUserDefaultsKey)
     }
     
+    func deactivateQuest(_ quest: Quest) {
+        var identifiers = activeQuestIdentifiersFromUserDefaults()
+        
+        identifiers.removeAll(where: { $0 == quest.identifier })
+        
+        userDefaults.set(identifiers, forKey: activeQuestIdentifierUserDefaultsKey)
+    }
+    
     private func activeQuestIdentifiersFromUserDefaults() -> [String] {
         guard
             let activeQuestIdentifiers = userDefaults.object(forKey: activeQuestIdentifierUserDefaultsKey) as? [String]

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -34,4 +34,8 @@ extension StaticQuestProvider: QuestProviding {
         [accessibleToiletsQuest,
          parkingFeeQuest]
     }
+    
+    func isQuestActive(_ quest: Quest) -> Bool {
+        return false
+    }
 }

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -86,6 +86,9 @@ extension StaticQuestProvider: QuestProviding {
         identifiers.removeAll(where: { $0 == quest.identifier })
         
         userDefaults.set(identifiers, forKey: activeQuestIdentifierUserDefaultsKey)
+        
+        /// Post a notification.
+        notificationCenter.post(name: .QuestManagerDidUpdateActiveQuests, object: self)
     }
     
     private func activeQuestIdentifiersFromUserDefaults() -> [String] {

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -18,11 +18,17 @@ class StaticQuestProvider {
     
     private let notificationCenter: NotificationCenter
     
+    // MARK: Public properties
+    
+    let quests: [Quest]
+    
     // MARK: Initializer
     
-    init(userDefaults: UserDefaults = .standard,
+    init(quests: [Quest] = [Quest.makeAccessibleToiletsQuest(), Quest.makeParkingFeeQuest()],
+         userDefaults: UserDefaults = .standard,
          activeQuestIdentifierUserDefaultsKey: String = "active_quest_identifiers",
          notificationCenter: NotificationCenter = .default) {
+        self.quests = quests
         self.userDefaults = userDefaults
         self.activeQuestIdentifierUserDefaultsKey = activeQuestIdentifierUserDefaultsKey
         self.notificationCenter = notificationCenter
@@ -30,10 +36,6 @@ class StaticQuestProvider {
 }
 
 extension StaticQuestProvider: QuestProviding {
-    var quests: [Quest] {
-        [Quest.makeAccessibleToiletsQuest(),
-         Quest.makeParkingFeeQuest()]
-    }
     
     func isQuestActive(_ quest: Quest) -> Bool {
         return activeQuestIdentifiersFromUserDefaults().contains(quest.identifier)

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -9,10 +9,12 @@
 /// Provides static `Quest`s that are compiled into the app.
 class StaticQuestProvider {
     private var accessibleToiletsQuest: Quest {
+        let identifier = "accessible_toilets"
         let question = "Are these toilets wheelchair accessible?"
         let query = "(type:node or type:way) and amenity=toilets and access !~ \"private|customers\" and wheelchair!=*"
         
-        return Quest(question: question,
+        return Quest(identifier: identifier,
+                     question: question,
                      overpassWizardQuery: query)
     }
 }

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -26,7 +26,8 @@ class StaticQuestProvider {
     
     init(quests: [Quest] = [Quest.makeAccessibleToiletsQuest(),
                             Quest.makeParkingFeeQuest(),
-                            Quest.makeBenchBackrestQuest()],
+                            Quest.makeBenchBackrestQuest(),
+                            Quest.makePlaygroundAccessQuest()],
          userDefaults: UserDefaults = .standard,
          activeQuestIdentifierUserDefaultsKey: String = "active_quest_identifiers",
          notificationCenter: NotificationCenter = .default) {

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -52,6 +52,12 @@ extension StaticQuestProvider: QuestProviding {
     }
     
     func isQuestActive(_ quest: Quest) -> Bool {
-        return false
+        guard
+            let activeQuestIdentifiers = userDefaults.object(forKey: activeQuestIdentifierUserDefaultsKey) as? [String]
+        else {
+            return false
+        }
+        
+        return activeQuestIdentifiers.contains(quest.identifier)
     }
 }

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -13,6 +13,9 @@ class StaticQuestProvider {
     /// The `UserDefaults` instances for persisting the active quests.
     private let userDefaults: UserDefaults
     
+    /// Key for when storing the identifiers of the active quests in the `UserDefaults`.
+    private let activeQuestIdentifierUserDefaultsKey: String
+    
     private var accessibleToiletsQuest: Quest {
         let identifier = "accessible_toilets"
         let question = "Are these toilets wheelchair accessible?"
@@ -35,8 +38,10 @@ class StaticQuestProvider {
     
     // MARK: Initializer
     
-    init(userDefaults: UserDefaults = .standard) {
+    init(userDefaults: UserDefaults = .standard,
+         activeQuestIdentifierUserDefaultsKey: String = "active_quest_identifiers") {
         self.userDefaults = userDefaults
+        self.activeQuestIdentifierUserDefaultsKey = activeQuestIdentifierUserDefaultsKey
     }
 }
 

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -1,0 +1,24 @@
+//
+//  StaticQuestProvider.swift
+//  Go Map!!
+//
+//  Created by Wolfgang Timme on 1/4/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+/// Provides static `Quest`s that are compiled into the app.
+class StaticQuestProvider {
+    private var accessibleToiletsQuest: Quest {
+        let question = "Are these toilets wheelchair accessible?"
+        let query = "(type:node or type:way) and amenity=toilets and access !~ \"private|customers\" and wheelchair!=*"
+        
+        return Quest(question: question,
+                     overpassWizardQuery: query)
+    }
+}
+
+extension StaticQuestProvider: QuestProviding {
+    var quests: [Quest] {
+        [accessibleToiletsQuest]
+    }
+}

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -8,6 +8,8 @@
 
 /// Provides static `Quest`s that are compiled into the app.
 class StaticQuestProvider {
+    // MARK: Private properties
+    
     private var accessibleToiletsQuest: Quest {
         let identifier = "accessible_toilets"
         let question = "Are these toilets wheelchair accessible?"

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -18,16 +18,6 @@ class StaticQuestProvider {
     
     private let notificationCenter: NotificationCenter
     
-    private var parkingFeeQuest: Quest {
-        let identifier = "parking_fee"
-        let question = "Does it cost a fee to park here? "
-        let query = "(type:node or type:way) and amenity=parking and fee!=* and access~\"yes|customers|public\""
-        
-        return Quest(identifier: identifier,
-                     question: question,
-                     overpassWizardQuery: query)
-    }
-    
     // MARK: Initializer
     
     init(userDefaults: UserDefaults = .standard,
@@ -42,7 +32,7 @@ class StaticQuestProvider {
 extension StaticQuestProvider: QuestProviding {
     var quests: [Quest] {
         [Quest.makeAccessibleToiletsQuest(),
-         parkingFeeQuest]
+         Quest.makeParkingFeeQuest()]
     }
     
     func isQuestActive(_ quest: Quest) -> Bool {

--- a/src/iOS/Overpass/QuestManager.swift
+++ b/src/iOS/Overpass/QuestManager.swift
@@ -11,7 +11,6 @@ protocol QuestManaging {
 }
 
 extension NSNotification.Name {
-    static let QuestManagerDidUpdateActiveQuest = Notification.Name("QuestManagerDidUpdateActiveQuest")
     static let QuestManagerDidUpdateActiveQuests = Notification.Name("QuestManagerDidUpdateActiveQuests")
 }
 
@@ -41,7 +40,7 @@ final class QuestManager: NSObject, QuestManaging {
             userDefaults.set(newValue, forKey: activeQueryUserDefaultsKey)
             
             if isUpdatedValue {
-                notificationCenter.post(name: .QuestManagerDidUpdateActiveQuest, object: self)
+                notificationCenter.post(name: .QuestManagerDidUpdateActiveQuests, object: self)
             }
         }
     }

--- a/src/iOS/Overpass/QuestManager.swift
+++ b/src/iOS/Overpass/QuestManager.swift
@@ -12,6 +12,7 @@ protocol QuestManaging {
 
 extension NSNotification.Name {
     static let QuestManagerDidUpdateActiveQuest = Notification.Name("QuestManagerDidUpdateActiveQuest")
+    static let QuestManagerDidUpdateActiveQuests = Notification.Name("QuestManagerDidUpdateActiveQuests")
 }
 
 final class QuestManager: NSObject, QuestManaging {


### PR DESCRIPTION
This branch implements #21, adding a list that contains quests which are pre-compiled into the app and not editable. The user can, however, activate and deactivate the quests.

When a quest is active, objects on the map are matched against the quest and, if they match, the objects are marked on the map - the same behaviour as with the existing "Overpass Turbo Query".

## Preview

![quest-list](https://user-images.githubusercontent.com/1681085/71783233-b5a42c00-2fdb-11ea-98f6-a77d14b958e9.jpg)

![benches-without-backrest](https://user-images.githubusercontent.com/1681085/71783232-b5a42c00-2fdb-11ea-8b08-f6cb7b71e6cd.jpg)