### PR TITLE
Fix: Use `UIAlertControllerStyleAlert` on iPad to prevent crash

### DIFF
--- a/src/Shared/MapView.m
+++ b/src/Shared/MapView.m
@@ -3559,9 +3559,14 @@ static NSString * const DisplayLinkPanning	= @"Panning";
 - (void)askMultipleChoiceQuestionWithQuestion:(NSString *)question
                                       choices:(NSArray<NSString *> *)choices
                              selectionHandler:(void (^)(NSInteger))selectionHandler {
+    UIAlertControllerStyle alertStyle = UIAlertControllerStyleActionSheet;
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        alertStyle = UIAlertControllerStyleAlert;
+    }
+    
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:question
                                                                              message:nil
-                                                                      preferredStyle:UIAlertControllerStyleActionSheet];
+                                                                      preferredStyle:alertStyle];
     
     [choices enumerateObjectsUsingBlock:^(NSString * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         UIAlertAction *choiceAction = [UIAlertAction actionWithTitle:obj style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
@@ -3583,9 +3588,14 @@ static NSString * const DisplayLinkPanning	= @"Panning";
 - (void)askNumericQuestionWithQuestion:(NSString *)question
                                    key:(NSString *)key
                                handler:(void (^)(NSString * _Nullable))handler {
+    UIAlertControllerStyle alertStyle = UIAlertControllerStyleActionSheet;
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        alertStyle = UIAlertControllerStyleAlert;
+    }
+    
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:question
                                                                              message:nil
-                                                                      preferredStyle:UIAlertControllerStyleAlert];
+                                                                      preferredStyle:alertStyle];
     
     __block __weak UITextField *answerTextField;
     [alertController addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {


### PR DESCRIPTION
This crash was reported via App Store Connect and seems to
happen because the `sourceView` and `sourceRect` of the
popover view controller is not properly set.

I tried setting them up properly, but wasn't able to in a
short amount of time. So for an MVP, I decided to just use
alerts instead of an action sheet for now.