### PR TITLE
Refactoring: Remove unused property `isAppUpgrade`

### DIFF
--- a/src/iOS/AppDelegate.h
+++ b/src/iOS/AppDelegate.h
@@ -21,8 +21,6 @@
 @property (strong,nonatomic)	NSString			*	userName;
 @property (strong,nonatomic)	NSString			*	userPassword;
 
-@property (readonly,nonatomic)	BOOL					isAppUpgrade;
-
 @property (strong,nonatomic)	ExternalGPS			*	externalGPS;
 
 -(NSString *)appName;

--- a/src/iOS/AppDelegate.m
+++ b/src/iOS/AppDelegate.m
@@ -39,16 +39,6 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-	NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
-
-	// save the app version so we can detect upgrades
-	NSString * prevVersion = [defaults objectForKey:@"appVersion"];
-	if ( ![prevVersion isEqualToString:self.appVersion] ) {
-		NSLog(@"Upgrade!");
-		_isAppUpgrade = YES;
-	}
-	[defaults setObject:self.appVersion forKey:@"appVersion"];
-
 	// read name/password from keychain
 	self.userName		= [KeyChain getStringForIdentifier:@"username"];
 	self.userPassword	= [KeyChain getStringForIdentifier:@"password"];


### PR DESCRIPTION
The property is only written to, but never actually read,
so this code can be removed to improve readability.