### PR TITLE
Feature: Add more quests

### DIFF
--- a/src/iOS/GoMapTests/Overpass/Queries/KeyValueQueryTestCase.swift
+++ b/src/iOS/GoMapTests/Overpass/Queries/KeyValueQueryTestCase.swift
@@ -36,5 +36,14 @@ class KeyValueQueryTestCase: XCTestCase {
         let query = KeyValueQuery(key: key, value: value)
         XCTAssertTrue(query.matches(object))
     }
+    
+    func testMatches_whenObjectDoesDoesNotHaveTagWithTheGivenKeyButIsNegated_shouldReturnTrue() {
+        let key = "access"
+        let value = "private"
+        let object = OsmBaseObject()
+        
+        let query = KeyValueQuery(key: key, value: value, isNegated: true)
+        XCTAssertTrue(query.matches(object))
+    }
 
 }

--- a/src/iOS/Overpass/Queries/KeyValueQuery.swift
+++ b/src/iOS/Overpass/Queries/KeyValueQuery.swift
@@ -22,7 +22,13 @@ extension KeyValueQuery: BaseObjectMatching {
     
     func matches(_ object: OsmBaseObject) -> Bool {
         guard let valueOfObject = object.tags?[key] as? String else {
-            return false
+            /// The object does not have a tag with the given key.
+            if isNegated {
+                /// Treat the absence of a tag with the given key as a match when the query is negated.
+                return true
+            } else {
+                return false
+            }
         }
         
         return valueOfObject == value

--- a/src/iOS/Overpass/Quest+staticQuests.swift
+++ b/src/iOS/Overpass/Quest+staticQuests.swift
@@ -79,6 +79,20 @@ extension Quest {
                      solution: solution)
     }
     
+    static func makeToiletFeeQuest() -> Quest {
+        let identifier = "toilet_fee"
+        let question = "Do these toilets require a fee?"
+        let query = "(type:node or type:way) and amenity = toilets and access !~ \"private|customers\" and fee!=*"
+        let answers = [Answer(title: "Yes", key: "fee", value: "yes"),
+                       Answer(title: "No", key: "fee", value: "no")]
+        let solution = Quest.Solution.multipleChoice(answers)
+        
+        return Quest(identifier: identifier,
+                     question: question,
+                     overpassWizardQuery: query,
+                     solution: solution)
+    }
+    
     static func makeBicycleParkingCoveredQuest() -> Quest {
         let identifier = "bicycle_parking_covered"
         let question = "Is this bicycle parking covered (protected from rain)?"

--- a/src/iOS/Overpass/Quest+staticQuests.swift
+++ b/src/iOS/Overpass/Quest+staticQuests.swift
@@ -162,4 +162,18 @@ extension Quest {
                      solution: solution)
     }
     
+    static func makeStepsHandrailQuest() -> Quest {
+        let identifier = "steps_handrail"
+        let question = "Do these steps have a handrail?"
+        let query = "type:way and highway=steps and handrail!=* and handrail:left!=* and handrail:center!=* and handrail:right!=*"
+        let answers = [Answer(title: "Yes", key: "handrail", value: "yes"),
+                       Answer(title: "No", key: "handrail", value: "no")]
+        let solution = Quest.Solution.multipleChoice(answers)
+        
+        return Quest(identifier: identifier,
+                     question: question,
+                     overpassWizardQuery: query,
+                     solution: solution)
+    }
+    
 }

--- a/src/iOS/Overpass/Quest+staticQuests.swift
+++ b/src/iOS/Overpass/Quest+staticQuests.swift
@@ -79,6 +79,20 @@ extension Quest {
                      solution: solution)
     }
     
+    static func makeBicycleParkingCoveredQuest() -> Quest {
+        let identifier = "bicycle_parking_covered"
+        let question = "Is this bicycle parking covered (protected from rain)?"
+        let query = "(type:node or type:way) and amenity=bicycle_parking and access!~\"private|no\" and covered!=* and bicycle_parking !~ \"shed|lockers|building\""
+        let answers = [Answer(title: "Yes", key: "covered", value: "yes"),
+                       Answer(title: "No", key: "covered", value: "no")]
+        let solution = Quest.Solution.multipleChoice(answers)
+        
+        return Quest(identifier: identifier,
+                     question: question,
+                     overpassWizardQuery: query,
+                     solution: solution)
+    }
+    
     static func makeBicycleParkingQuest() -> Quest {
         let identifier = "bicycle_parking"
         let question = "How many bikes can be parked here?"

--- a/src/iOS/Overpass/Quest+staticQuests.swift
+++ b/src/iOS/Overpass/Quest+staticQuests.swift
@@ -134,4 +134,18 @@ extension Quest {
                      solution: solution)
     }
     
+    static func makeBusStopShelterQuest() -> Quest {
+        let identifier = "bus_stop_shelter"
+        let question = "Does this bus stop have a shelter?"
+        let query = "type:node and (public_transport=platform or (highway=bus_stop and public_transport!=stop_position)) and shelter!=*"
+        let answers = [Answer(title: "Yes", key: "shelter", value: "yes"),
+                       Answer(title: "No", key: "shelter", value: "no")]
+        let solution = Quest.Solution.multipleChoice(answers)
+        
+        return Quest(identifier: identifier,
+                     question: question,
+                     overpassWizardQuery: query,
+                     solution: solution)
+    }
+    
 }

--- a/src/iOS/Overpass/Quest+staticQuests.swift
+++ b/src/iOS/Overpass/Quest+staticQuests.swift
@@ -93,6 +93,23 @@ extension Quest {
                      solution: solution)
     }
     
+    static func makeBicycleParkingTypeQuest() -> Quest {
+        let identifier = "bicycle_parking_type"
+        let question = "What is the type of this bicycle parking?"
+        let query = "(type:node or type:way) and amenity=bicycle_parking and bicycle_parking!=* and access!=private"
+        let answers = [Answer(title: "Building", key: "bicycle_parking", value: "building"),
+                       Answer(title: "Locker", key: "bicycle_parking", value: "lockers"),
+                       Answer(title: "Shed", key: "bicycle_parking", value: "shed"),
+                       Answer(title: "Stand", key: "bicycle_parking", value: "stands"),
+                       Answer(title: "Wheelbender", key: "bicycle_parking", value: "wall_loops")]
+        let solution = Quest.Solution.multipleChoice(answers)
+        
+        return Quest(identifier: identifier,
+                     question: question,
+                     overpassWizardQuery: query,
+                     solution: solution)
+    }
+    
     static func makeBicycleParkingQuest() -> Quest {
         let identifier = "bicycle_parking"
         let question = "How many bikes can be parked here?"

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -29,6 +29,7 @@ class StaticQuestProvider {
                             Quest.makeBenchBackrestQuest(),
                             Quest.makePlaygroundAccessQuest(),
                             Quest.makeToiletQuest(),
+                            Quest.makeToiletFeeQuest(),
                             Quest.makeBicycleParkingQuest(),
                             Quest.makeBicycleParkingCoveredQuest(),
                             Quest.makeBicycleParkingTypeQuest(),

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -34,7 +34,8 @@ class StaticQuestProvider {
                             Quest.makeBicycleParkingCoveredQuest(),
                             Quest.makeBicycleParkingTypeQuest(),
                             Quest.makeMotorcycleParkingQuest(),
-                            Quest.makeBusStopShelterQuest()],
+                            Quest.makeBusStopShelterQuest(),
+                            Quest.makeStepsHandrailQuest()],
          userDefaults: UserDefaults = .standard,
          activeQuestIdentifierUserDefaultsKey: String = "active_quest_identifiers",
          notificationCenter: NotificationCenter = .default) {

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -31,6 +31,7 @@ class StaticQuestProvider {
                             Quest.makeToiletQuest(),
                             Quest.makeBicycleParkingQuest(),
                             Quest.makeBicycleParkingCoveredQuest(),
+                            Quest.makeBicycleParkingTypeQuest(),
                             Quest.makeMotorcycleParkingQuest()],
          userDefaults: UserDefaults = .standard,
          activeQuestIdentifierUserDefaultsKey: String = "active_quest_identifiers",

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -32,7 +32,8 @@ class StaticQuestProvider {
                             Quest.makeBicycleParkingQuest(),
                             Quest.makeBicycleParkingCoveredQuest(),
                             Quest.makeBicycleParkingTypeQuest(),
-                            Quest.makeMotorcycleParkingQuest()],
+                            Quest.makeMotorcycleParkingQuest(),
+                            Quest.makeBusStopShelterQuest()],
          userDefaults: UserDefaults = .standard,
          activeQuestIdentifierUserDefaultsKey: String = "active_quest_identifiers",
          notificationCenter: NotificationCenter = .default) {

--- a/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
+++ b/src/iOS/Overpass/QuestList/StaticQuestProvider.swift
@@ -30,6 +30,7 @@ class StaticQuestProvider {
                             Quest.makePlaygroundAccessQuest(),
                             Quest.makeToiletQuest(),
                             Quest.makeBicycleParkingQuest(),
+                            Quest.makeBicycleParkingCoveredQuest(),
                             Quest.makeMotorcycleParkingQuest()],
          userDefaults: UserDefaults = .standard,
          activeQuestIdentifierUserDefaultsKey: String = "active_quest_identifiers",


### PR DESCRIPTION
This branch adds five more quests:

- Do these toilets require a fee?
- Is this bicycle parking covered (protected from rain)?
- What is the type of this bicycle parking?
- Does this bus stop have a shelter?
- Do these steps have a handrail?

In addition, while implementing the bicycle-parking-type quest, I noticed that there was an issue with the `KeyValueQuery`. It did not work properly when `isNegated` was set to `true`. I also fixed that, so now a `KeyValueQuery` can be negated properly.