### PR TITLE
Feature: Use "Unreleased" section of CHANGELOG.md as the changelog for TestFlight

### DIFF
--- a/src/iOS/fastlane/Fastfile
+++ b/src/iOS/fastlane/Fastfile
@@ -16,15 +16,6 @@ platform :ios do
     )
   end
 
-  lane :run_stamp_changelog do
-    stamp_changelog(
-      changelog_path: './CHANGELOG.md',
-      section_identifier: '2.0.0 (42)',
-      git_tag: "builds/beta/2.0.0-42",
-      stamp_date: "true"
-    )
-  end
-
   desc "Uploads a new Beta version to TestFlight"
   lane :beta do
     pull_request_checks

--- a/src/iOS/fastlane/Fastfile
+++ b/src/iOS/fastlane/Fastfile
@@ -1,6 +1,9 @@
 # Disable metrics
 opt_out_usage
 
+# Configuration
+CHANGELOG_PATH = "./CHANGELOG.md"
+
 default_platform(:ios)
 
 platform :ios do
@@ -35,10 +38,9 @@ platform :ios do
     git_tag = "builds/beta/#{get_version_number()}-#{get_build_number()}"
 
     # Update the changelog
-    changelog_path = './CHANGELOG.md'
     section_identifier = "#{get_version_number()} (#{get_build_number()})"
     stamp_changelog(
-      changelog_path: changelog_path,
+      changelog_path: CHANGELOG_PATH,
       section_identifier: section_identifier,
       git_tag: git_tag,
       stamp_date: 'true'

--- a/src/iOS/fastlane/Fastfile
+++ b/src/iOS/fastlane/Fastfile
@@ -28,6 +28,10 @@ platform :ios do
     # Determine the tag (e. g. 'builds/beta/1.6.5-12')
     git_tag = "builds/beta/#{get_version_number()}-#{get_build_number()}"
 
+    # Read the "Unreleased" section of the changelog.
+    # This will later be used when uploading the build to TestFlight.
+    changelog = read_changelog(changelog_path: CHANGELOG_PATH)
+
     # Update the changelog
     section_identifier = "#{get_version_number()} (#{get_build_number()})"
     stamp_changelog(
@@ -52,7 +56,9 @@ platform :ios do
 
     push_to_git_remote
 
-    upload_to_testflight
+    upload_to_testflight(
+      changelog: changelog
+    )
   end
 
   desc "Re-generates the app icon from the base app_icon.png in the fastlane metadata directory"

--- a/src/iOS/fastlane/README.md
+++ b/src/iOS/fastlane/README.md
@@ -21,11 +21,6 @@ or alternatively using `brew cask install fastlane`
 fastlane ios pull_request_checks
 ```
 Performs basic integration checks to be run before merging
-### ios run_stamp_changelog
-```
-fastlane ios run_stamp_changelog
-```
-
 ### ios beta
 ```
 fastlane ios beta


### PR DESCRIPTION
This branch configures fastlane so that the "Unreleased" section of the CHANGELOG.md file is being used as the "changelog" when uploading a build to TestFlight.